### PR TITLE
fix: remove inflex dependency

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 RUN apt-get update && apt-get install -y \
     inotify-tools \
     ca-certificates \
+    openssh-client \
     && apt-get clean
 
 # Create the vscode user

--- a/.github/workflows/ci_code.yml
+++ b/.github/workflows/ci_code.yml
@@ -35,7 +35,7 @@ jobs:
         uses: erlef/setup-beam@v1
         with:
           otp-version: 27.2
-          elixir-version: 1.18.1
+          elixir-version: 1.18.4
 
       - name: Install chrome
         uses: browser-actions/setup-chrome@v1

--- a/valentine/lib/valentine_web/live/workspace_live/reference_packs/index.html.heex
+++ b/valentine/lib/valentine_web/live/workspace_live/reference_packs/index.html.heex
@@ -24,8 +24,7 @@
             ~p"/workspaces/#{@workspace.id}/reference_packs/#{reference_pack.collection_id}/#{reference_pack.collection_type}"
           }>
             <h4>
-              {Phoenix.Naming.humanize(reference_pack.collection_type)
-              |> Inflex.pluralize()} pack: {reference_pack.collection_name}
+              {Phoenix.Naming.humanize(reference_pack.collection_type)} pack: {reference_pack.collection_name}
             </h4>
           </.link>
         </div>

--- a/valentine/mix.exs
+++ b/valentine/mix.exs
@@ -5,7 +5,7 @@ defmodule Valentine.MixProject do
     [
       app: :valentine,
       version: "0.1.0",
-      elixir: "~> 1.18",
+      elixir: "~> 1.18.4",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
@@ -55,7 +55,6 @@ defmodule Valentine.MixProject do
       {:mdex, "~> 0.2"},
       {:langchain, github: "brainlid/langchain", ref: "315e787c7f4e52c014b52bda0142aa631d3dd28f"},
       {:cachex, "~> 4.0"},
-      {:inflex, "~> 2.0.0"},
       {:csv, "~> 3.2"},
       {:ueberauth_google, "~> 0.10"},
       {:ueberauth_cognito, "~> 0.3"},

--- a/valentine/mix.lock
+++ b/valentine/mix.lock
@@ -27,7 +27,6 @@
   "heroicons": {:git, "https://github.com/tailwindlabs/heroicons.git", "88ab3a0d790e6a47404cba02800a6b25d2afae50", [tag: "v2.1.1", sparse: "optimized", depth: 1]},
   "hpax": {:hex, :hpax, "1.0.3", "ed67ef51ad4df91e75cc6a1494f851850c0bd98ebc0be6e81b026e765ee535aa", [:mix], [], "hexpm", "8eab6e1cfa8d5918c2ce4ba43588e894af35dbd8e91e6e55c817bca5847df34a"},
   "idna": {:hex, :idna, "6.1.1", "8a63070e9f7d0c62eb9d9fcb360a7de382448200fbbd1b106cc96d3d8099df8d", [:rebar3], [{:unicode_util_compat, "~> 0.7.0", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm", "92376eb7894412ed19ac475e4a86f7b413c1b9fbb5bd16dccd57934157944cea"},
-  "inflex": {:hex, :inflex, "2.0.0", "db69d542b8fdb23ac667f9bc0c2395a3983fa2da6ae2efa7ab5dc541928f7a75", [:mix], [], "hexpm", "c018852409bd48b03ad96ed53594186bc074bdd1519043a0ad1fa5697aac4399"},
   "jason": {:hex, :jason, "1.4.4", "b9226785a9aa77b6857ca22832cffa5d5011a667207eb2a0ad56adb5db443b8a", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "c5eb0cab91f094599f94d55bc63409236a8ec69a21a67814529e8d5f6cc90b3b"},
   "jose": {:hex, :jose, "1.11.10", "a903f5227417bd2a08c8a00a0cbcc458118be84480955e8d251297a425723f83", [:mix, :rebar3], [], "hexpm", "0d6cd36ff8ba174db29148fc112b5842186b68a90ce9fc2b3ec3afe76593e614"},
   "jumper": {:hex, :jumper, "1.0.2", "68cdcd84472a00ac596b4e6459a41b3062d4427cbd4f1e8c8793c5b54f1406a7", [:mix], [], "hexpm", "9b7782409021e01ab3c08270e26f36eb62976a38c1aa64b2eaf6348422f165e1"},

--- a/valentine/test/valentine_web/live/workspace/reference_packs/index_view_test.exs
+++ b/valentine/test/valentine_web/live/workspace/reference_packs/index_view_test.exs
@@ -28,7 +28,7 @@ defmodule ValentineWeb.WorkspaceLive.ReferencePacks.IndexViewTest do
       assert html =~ reference_pack_item.collection_name
 
       assert html =~
-               Phoenix.Naming.humanize(reference_pack_item.collection_type) |> Inflex.pluralize()
+               Phoenix.Naming.humanize(reference_pack_item.collection_type)
     end
 
     test "imports reference packs into workspace", %{


### PR DESCRIPTION
# Summary
Remove the dependency as it is not well maintained and has an open bug with OTP 28.  As this dependency is only used in one spot for a simple pluralization, it is safe to remove without replacement.

Pin the project's Elixir version to the same version in the Dockerfile and CI workflows.

Add the `openssh-client` dependency to the devcontainer so that local devcontainers can use SSH to interact with the GitHub repo.

# Related
- https://github.com/cds-snc/platform-core-services/issues/783
- https://github.com/nurugger07/inflex/issues/98