### PR TITLE
fix: wait for ECS deployment to stabilize

### DIFF
--- a/.github/workflows/cd_docker.yml
+++ b/.github/workflows/cd_docker.yml
@@ -59,3 +59,7 @@ jobs:
       - name: Deploy to ECS
         run: |
           aws ecs update-service --cluster valentine-cluster --service valentine-service --force-new-deployment > /dev/null 2>&1
+
+      - name: Wait for service to stabilize
+        run: |
+          aws ecs wait services-stable --cluster valentine-cluster --services valentine-service > /dev/null 2>&1


### PR DESCRIPTION
# Summary
Add a step that waits for the ECS deployment to stabilize after update. This prevents edge cases where deployment errors do not stabilize and a long running failing deployment occurs.

This will poll the updated service every 15 seconds and be marked as a failed workflow after 40 failed checks.