### PR TITLE
feat: add NIST family filter to SRTM View

### DIFF
--- a/valentine/lib/valentine_web/controllers/workspace/excel.ex
+++ b/valentine/lib/valentine_web/controllers/workspace/excel.ex
@@ -9,7 +9,9 @@ defmodule ValentineWeb.Workspace.Excel do
       if workspace.cloud_profile == nil && workspace.cloud_profile_type == nil do
         Composer.list_controls()
       else
-        Composer.list_controls_by_tags([workspace.cloud_profile, workspace.cloud_profile_type])
+        Composer.list_controls_by_filters(%{
+          tags: [workspace.cloud_profile, workspace.cloud_profile_type]
+        })
       end
       |> sort_into_families()
       |> append_tagged_entities(workspace)

--- a/valentine/lib/valentine_web/live/workspace_live/controls/index.html.heex
+++ b/valentine/lib/valentine_web/live/workspace_live/controls/index.html.heex
@@ -11,7 +11,7 @@
     <.live_component
       module={ValentineWeb.WorkspaceLive.Components.FilterComponent}
       id="nist-family-filter"
-      icon="filter"
+      icon="shield-lock"
       class=""
       name={:nist_family}
       values={@nist_families}

--- a/valentine/lib/valentine_web/live/workspace_live/srtm/index.html.heex
+++ b/valentine/lib/valentine_web/live/workspace_live/srtm/index.html.heex
@@ -49,6 +49,15 @@
       ]}
       filters={@filters}
     />
+    <.live_component
+      module={ValentineWeb.WorkspaceLive.Components.FilterComponent}
+      id="nist-family-filter"
+      class="mx-1"
+      icon="shield-lock"
+      name={:nist_family}
+      values={@nist_families}
+      filters={@filters}
+    />
   </:header>
 
   <div class="clearfix">

--- a/valentine/test/valentine/composer_test.exs
+++ b/valentine/test/valentine/composer_test.exs
@@ -1080,20 +1080,33 @@ defmodule Valentine.ComposerTest do
       assert Composer.list_controls() == [control]
     end
 
-    test "list_controls_by_tags/2 returns all controls with given tags" do
+    test "list_controls_by_filters/0 returns all controls with given tags" do
       control = control_fixture(tags: ["tag1", "tag2"])
-      assert Composer.list_controls_by_tags(control.tags) == [control]
+      assert Composer.list_controls_by_filters(%{tags: control.tags}) == [control]
     end
 
-    test "list_controls_by_tags/2 returns all controls with given tags and not other controls" do
+    test "list_controls_by_filters/0 returns all controls with given tags and not other controls" do
       control_fixture(tags: ["tag1", "tag2"])
-      assert Composer.list_controls_by_tags(["tag3"]) == []
+      assert Composer.list_controls_by_filters(%{tags: ["tag3"]}) == []
     end
 
-    test "list controls_by_tags/2, will optionally filter by class as well" do
+    test "list_controls_by_filters/0, will filter by class" do
       control = control_fixture(tags: ["tag1", "tag2"], class: "some class")
       control_fixture(tags: ["tag1", "tag2"], class: "other class")
-      assert Composer.list_controls_by_tags(control.tags, ["some class"]) == [control]
+
+      assert Composer.list_controls_by_filters(%{classes: ["some class"]}) ==
+               [control]
+    end
+
+    test "list_controls_by_filters/0 will optionally filter by class and family as well" do
+      control = control_fixture(tags: ["tag1", "tag2"], class: "some class", nist_id: "AC-1")
+      control_fixture(tags: ["tag1", "tag2"], class: "other class", nist_id: "AC-2")
+
+      assert Composer.list_controls_by_filters(%{
+               tags: control.tags,
+               classes: ["some class"],
+               nist_families: ["AC"]
+             }) == [control]
     end
 
     test "list_control_families/0 returns all control families" do


### PR DESCRIPTION
# Summary
Add a new NIST family filter to the SRTM view that behaves in the same way as the filter on the NIST Controls screen.

<img width="1017" height="891" alt="image" src="https://github.com/user-attachments/assets/aaca263c-9718-4e27-9f8a-2df56bab0258" />


This is being done in preparation from adding the ability to set control allocation from the SRTM View.

# Related
- https://github.com/cds-snc/platform-core-services/issues/791