### PR TITLE
fix: improved DFD MCP guidance

### DIFF
--- a/valentine/lib/valentine/mcp/registry.ex
+++ b/valentine/lib/valentine/mcp/registry.ex
@@ -253,6 +253,8 @@ defmodule Valentine.MCP.Registry do
         """
         Update the data flow diagram for the current workspace. Use only Navigator-supported node types:
         actor, process, datastore, and trust_boundary. Model external services as actor nodes unless they are internal processes or datastores.
+        Include position.x and position.y for each node to control the rendered layout; omitted positions are auto-assigned and reported in validation_hints.
+        To place a node inside a trust_boundary, set the child node's data.parent to the trust_boundary node ID.
         """,
         schema(%{
           nodes: dfd_nodes_schema(),
@@ -428,7 +430,10 @@ defmodule Valentine.MCP.Registry do
                 "Navigator-supported node type. Use actor for users, clients, and external systems; process for application services; datastore for persistent stores; trust_boundary only for grouping."
             },
             description: string("Optional node description."),
-            parent: string("Optional parent trust_boundary node ID."),
+            parent:
+              string(
+                "Optional parent trust_boundary node ID. Set this on child nodes to render them inside a trust_boundary container."
+              ),
             linked_threats: string_array("Threat IDs linked to this node."),
             data_tags: string_array("Data classification tags."),
             security_tags: string_array("Security feature tags."),
@@ -440,6 +445,8 @@ defmodule Valentine.MCP.Registry do
         },
         position: %{
           type: "object",
+          description:
+            "Rendered node coordinates. Strongly recommended; omitted or malformed positions are auto-assigned and returned in validation_hints.",
           properties: %{x: %{type: "number"}, y: %{type: "number"}},
           additionalProperties: true
         },

--- a/valentine/lib/valentine/mcp/tools/documents.ex
+++ b/valentine/lib/valentine/mcp/tools/documents.ex
@@ -62,13 +62,14 @@ defmodule Valentine.MCP.Tools.Documents do
   def update_data_flow_diagram(args, api_key) do
     dfd = DataFlowDiagram.get(api_key.workspace_id)
     attrs = Map.take(args, ["nodes", "edges", "raw_image"])
+    {attrs, normalization_hints} = normalize_dfd_attrs(attrs)
 
     case validate_dfd_attrs(attrs, dfd) do
       :ok ->
         case Composer.update_data_flow_diagram(dfd, attrs) do
           {:ok, dfd} ->
             DataFlowDiagram.put(dfd)
-            ok_json(dfd_map(dfd))
+            ok_json(Map.put(dfd_map(dfd), :validation_hints, dfd_hints(dfd, normalization_hints)))
 
           {:error, changeset} ->
             tool_error(Jason.encode!(format_changeset_errors(changeset)))
@@ -114,6 +115,30 @@ defmodule Valentine.MCP.Tools.Documents do
     }
   end
 
+  defp normalize_dfd_attrs(%{"nodes" => nodes} = attrs) when is_map(nodes) do
+    {nodes, positioned_node_ids} =
+      nodes
+      |> Map.keys()
+      |> Enum.sort()
+      |> Enum.with_index()
+      |> Enum.reduce({nodes, []}, fn {id, index}, {acc, positioned_node_ids} ->
+        node = Map.get(acc, id)
+
+        if is_map(node) && !valid_position?(Map.get(node, "position")) do
+          {
+            Map.put(acc, id, Map.put(node, "position", auto_position(index))),
+            [id | positioned_node_ids]
+          }
+        else
+          {acc, positioned_node_ids}
+        end
+      end)
+
+    {Map.put(attrs, "nodes", nodes), %{auto_positioned_nodes: Enum.reverse(positioned_node_ids)}}
+  end
+
+  defp normalize_dfd_attrs(attrs), do: {attrs, %{auto_positioned_nodes: []}}
+
   defp validate_dfd_attrs(attrs, dfd) do
     effective_nodes = Map.get(attrs, "nodes", dfd.nodes)
     effective_edges = Map.get(attrs, "edges", dfd.edges)
@@ -136,7 +161,7 @@ defmodule Valentine.MCP.Tools.Documents do
 
   defp validate_nodes(_nodes), do: {:error, "DFD nodes must be an object"}
 
-  defp validate_node(id, %{"data" => %{} = data}) when is_binary(id) do
+  defp validate_node(id, %{"data" => %{} = data} = node) when is_binary(id) do
     cond do
       Map.get(data, "id") != id ->
         {:error, "DFD node #{id} data.id must match the node key"}
@@ -146,6 +171,9 @@ defmodule Valentine.MCP.Tools.Documents do
 
       Map.get(data, "type") not in @node_types ->
         {:error, "DFD node #{id} has an unsupported data.type"}
+
+      !valid_position?(Map.get(node, "position")) ->
+        {:error, "DFD node #{id} must include position.x and position.y numbers"}
 
       true ->
         :ok
@@ -203,4 +231,129 @@ defmodule Valentine.MCP.Tools.Documents do
        do: {:error, "DFD raw_image must be a string"}
 
   defp validate_raw_image(_attrs), do: :ok
+
+  defp valid_position?(%{"x" => x, "y" => y}) when is_number(x) and is_number(y), do: true
+  defp valid_position?(_position), do: false
+
+  defp auto_position(index) do
+    %{
+      "x" => rem(index, 4) * 260,
+      "y" => div(index, 4) * 180
+    }
+  end
+
+  defp dfd_hints(dfd, normalization_hints) do
+    []
+    |> maybe_add_auto_position_hint(
+      normalization_hints.auto_positioned_nodes,
+      map_size(dfd.nodes)
+    )
+    |> maybe_add_orphan_trust_boundary_hint(dfd.nodes)
+    |> maybe_add_long_label_hint(dfd.nodes)
+    |> maybe_add_overlapping_position_hint(dfd.nodes)
+    |> Enum.reverse()
+  end
+
+  defp maybe_add_auto_position_hint(hints, [], _node_count), do: hints
+
+  defp maybe_add_auto_position_hint(hints, node_ids, node_count) do
+    [
+      %{
+        code: "auto_positioned_nodes",
+        severity: "warning",
+        message:
+          "Some DFD nodes did not include usable position.x and position.y values, so Navigator assigned grid positions to avoid collapsed rendering.",
+        node_ids: node_ids,
+        count: length(node_ids),
+        total_nodes: node_count
+      }
+      | hints
+    ]
+  end
+
+  defp maybe_add_orphan_trust_boundary_hint(hints, nodes) do
+    orphan_ids =
+      nodes
+      |> Enum.filter(fn {_id, node} -> get_in(node, ["data", "type"]) == "trust_boundary" end)
+      |> Enum.reject(fn {id, _node} -> trust_boundary_has_children?(nodes, id) end)
+      |> Enum.map(fn {id, _node} -> id end)
+
+    case orphan_ids do
+      [] ->
+        hints
+
+      _ ->
+        [
+          %{
+            code: "orphan_trust_boundaries",
+            severity: "warning",
+            message:
+              "Trust boundaries render as useful containers only when child nodes set data.parent to the boundary node ID.",
+            node_ids: orphan_ids
+          }
+          | hints
+        ]
+    end
+  end
+
+  defp trust_boundary_has_children?(nodes, boundary_id) do
+    Enum.any?(nodes, fn {_id, node} -> get_in(node, ["data", "parent"]) == boundary_id end)
+  end
+
+  defp maybe_add_long_label_hint(hints, nodes) do
+    long_label_ids =
+      nodes
+      |> Enum.filter(fn {_id, node} ->
+        label = get_in(node, ["data", "label"])
+        is_binary(label) && String.length(label) > 60
+      end)
+      |> Enum.map(fn {id, _node} -> id end)
+
+    case long_label_ids do
+      [] ->
+        hints
+
+      _ ->
+        [
+          %{
+            code: "long_labels",
+            severity: "warning",
+            message:
+              "Long DFD labels can overlap nearby nodes; prefer concise labels and details in data.description.",
+            node_ids: long_label_ids
+          }
+          | hints
+        ]
+    end
+  end
+
+  defp maybe_add_overlapping_position_hint(hints, nodes) do
+    overlapping_ids =
+      nodes
+      |> Enum.group_by(fn {_id, node} ->
+        position = Map.get(node, "position")
+        {Map.get(position, "x"), Map.get(position, "y")}
+      end)
+      |> Enum.filter(fn {_position, grouped_nodes} -> length(grouped_nodes) > 1 end)
+      |> Enum.flat_map(fn {_position, grouped_nodes} ->
+        Enum.map(grouped_nodes, fn {id, _node} -> id end)
+      end)
+      |> Enum.sort()
+
+    case overlapping_ids do
+      [] ->
+        hints
+
+      _ ->
+        [
+          %{
+            code: "overlapping_positions",
+            severity: "warning",
+            message: "Multiple DFD nodes share the same position and may visually overlap.",
+            node_ids: overlapping_ids
+          }
+          | hints
+        ]
+    end
+  end
 end

--- a/valentine/test/valentine_web/controllers/api/mcp_controller_test.exs
+++ b/valentine/test/valentine_web/controllers/api/mcp_controller_test.exs
@@ -160,7 +160,8 @@ defmodule ValentineWeb.Api.MCPControllerTest do
         })
       )
 
-    assert get_in(json_response(conn, 200), ["result", "isError"]) == false
+    body = json_response(conn, 200)
+    assert get_in(body, ["result", "isError"]) == false
 
     conn =
       recycle(conn)
@@ -200,7 +201,21 @@ defmodule ValentineWeb.Api.MCPControllerTest do
         })
       )
 
-    assert get_in(json_response(conn, 200), ["result", "isError"]) == false
+    body = json_response(conn, 200)
+    assert get_in(body, ["result", "isError"]) == false
+
+    assert [%{"type" => "text", "text" => text}] = get_in(body, ["result", "content"])
+    dfd = Jason.decode!(text)
+
+    assert get_in(dfd, ["nodes", "app", "position"]) == %{"x" => 0, "y" => 0}
+    assert get_in(dfd, ["nodes", "browser", "position"]) == %{"x" => 260, "y" => 0}
+
+    assert %{
+             "code" => "auto_positioned_nodes",
+             "node_ids" => auto_positioned_node_ids
+           } = Enum.find(dfd["validation_hints"], &(&1["code"] == "auto_positioned_nodes"))
+
+    assert Enum.sort(auto_positioned_node_ids) == ["app", "browser"]
 
     conn =
       recycle(conn)
@@ -216,6 +231,47 @@ defmodule ValentineWeb.Api.MCPControllerTest do
     assert mermaid =~ "stateDiagram-v2"
     assert mermaid =~ "browser : Browser"
     assert mermaid =~ "browser --> app : HTTPS"
+  end
+
+  test "returns DFD usability hints for orphan trust boundaries", %{conn: conn} do
+    conn =
+      post(
+        conn,
+        ~p"/mcp",
+        rpc("tools/call", %{
+          "name" => "update_data_flow_diagram",
+          "arguments" => %{
+            "nodes" => %{
+              "public_boundary" => %{
+                "data" => %{
+                  "id" => "public_boundary",
+                  "label" => "Public Edge Boundary",
+                  "type" => "trust_boundary"
+                }
+              },
+              "browser" => %{
+                "data" => %{
+                  "id" => "browser",
+                  "label" => "Browser",
+                  "type" => "actor"
+                }
+              }
+            },
+            "edges" => %{}
+          }
+        })
+      )
+
+    body = json_response(conn, 200)
+    assert get_in(body, ["result", "isError"]) == false
+
+    assert [%{"type" => "text", "text" => text}] = get_in(body, ["result", "content"])
+    dfd = Jason.decode!(text)
+
+    assert %{
+             "code" => "orphan_trust_boundaries",
+             "node_ids" => ["public_boundary"]
+           } = Enum.find(dfd["validation_hints"], &(&1["code"] == "orphan_trust_boundaries"))
   end
 
   test "rejects malformed DFD payloads", %{conn: conn} do


### PR DESCRIPTION
This pull request enhances the handling and validation of Data Flow Diagram (DFD) nodes in the Valentine MCP system. The main improvements include enforcing and auto-assigning node positions for better diagram layout, providing detailed usability hints for DFD authors, and updating documentation and tests to reflect these changes.

**DFD Node Positioning and Validation:**

- Enforces that each DFD node must include valid `position.x` and `position.y` values; if missing or malformed, positions are auto-assigned to prevent node overlap and improve layout. (F81d3bdcL115R115, [[1]](diffhunk://#diff-d24ed8e736481d4f153794dacfd32f061ee8af4bb3ee771f79359d2cc05d5934R175-R177) [[2]](diffhunk://#diff-d24ed8e736481d4f153794dacfd32f061ee8af4bb3ee771f79359d2cc05d5934R234-R358)
- Updates DFD schema and documentation to clarify the requirement and usage of node positions, including how to nest nodes within trust boundaries using the `parent` field. [[1]](diffhunk://#diff-6f06e8319fa3292ca9dc6e55609e3cfa4c144fdce9e05d1785f2ac76473226c9R256-R257) [[2]](diffhunk://#diff-6f06e8319fa3292ca9dc6e55609e3cfa4c144fdce9e05d1785f2ac76473226c9L431-R436) [[3]](diffhunk://#diff-6f06e8319fa3292ca9dc6e55609e3cfa4c144fdce9e05d1785f2ac76473226c9R448-R449)

**Usability Hints and Feedback:**

- Introduces a `validation_hints` field in the DFD response, providing warnings for auto-positioned nodes, orphan trust boundaries (those without children), long labels, and overlapping node positions to guide users in improving their diagrams. [[1]](diffhunk://#diff-d24ed8e736481d4f153794dacfd32f061ee8af4bb3ee771f79359d2cc05d5934R65-R72) [[2]](diffhunk://#diff-d24ed8e736481d4f153794dacfd32f061ee8af4bb3ee771f79359d2cc05d5934R234-R358)

**Testing Enhancements:**

- Adds and updates tests to verify that auto-positioning and validation hints work as expected, including specific cases for auto-positioned nodes and orphan trust boundaries. [[1]](diffhunk://#diff-8e1142a8430d75e4d577cc24fa869c92e416530ebef2e024f53008ebcf6a1fa8L163-R164) [[2]](diffhunk://#diff-8e1142a8430d75e4d577cc24fa869c92e416530ebef2e024f53008ebcf6a1fa8L203-R218) [[3]](diffhunk://#diff-8e1142a8430d75e4d577cc24fa869c92e416530ebef2e024f53008ebcf6a1fa8R236-R276)

These changes collectively improve the robustness, usability, and clarity of DFD editing and validation in the MCP system.