### PR TITLE
fix: DFD improvements

### DIFF
--- a/valentine/lib/valentine/composer/data_flow_diagram.ex
+++ b/valentine/lib/valentine/composer/data_flow_diagram.ex
@@ -6,6 +6,25 @@ defmodule Valentine.Composer.DataFlowDiagram do
   alias Valentine.Composer
 
   @history_limit 50
+  @node_data_defaults %{
+    "data_tags" => [],
+    "description" => nil,
+    "linked_threats" => [],
+    "out_of_scope" => "false",
+    "parent" => nil,
+    "security_tags" => [],
+    "technology_tags" => []
+  }
+  @edge_data_defaults %{
+    "data_tags" => [],
+    "description" => nil,
+    "label" => "Data flow",
+    "linked_threats" => [],
+    "out_of_scope" => "false",
+    "security_tags" => [],
+    "technology_tags" => [],
+    "type" => "edge"
+  }
 
   @primary_key {:id, Ecto.UUID, autogenerate: true}
   @foreign_key_type :binary_id
@@ -166,6 +185,32 @@ defmodule Valentine.Composer.DataFlowDiagram do
       new(workspace_id) |> put()
     end
   end
+
+  def normalize_nodes(nodes) when is_map(nodes) do
+    Map.new(nodes, fn {id, node} -> {id, normalize_node(node)} end)
+  end
+
+  def normalize_nodes(nodes), do: nodes
+
+  def normalize_edges(edges) when is_map(edges) do
+    Map.new(edges, fn {id, edge} -> {id, normalize_edge(edge)} end)
+  end
+
+  def normalize_edges(edges), do: edges
+
+  def normalize_node(%{"data" => data} = node) when is_map(data) do
+    node
+    |> Map.put("data", put_defaults(data, @node_data_defaults))
+    |> put_default("grabbable", "true")
+  end
+
+  def normalize_node(node), do: node
+
+  def normalize_edge(%{"data" => data} = edge) when is_map(data) do
+    Map.put(edge, "data", put_defaults(data, @edge_data_defaults))
+  end
+
+  def normalize_edge(edge), do: edge
 
   def grab(workspace_id, %{"node" => node}) do
     dfd = get(workspace_id)
@@ -590,6 +635,19 @@ defmodule Valentine.Composer.DataFlowDiagram do
   defp find_children(nodes, parent_id) do
     nodes
     |> Enum.filter(fn {_, node} -> node["data"]["parent"] == parent_id end)
+  end
+
+  defp put_defaults(map, defaults) do
+    Enum.reduce(defaults, map, fn {key, default}, acc ->
+      put_default(acc, key, default)
+    end)
+  end
+
+  defp put_default(map, key, default) do
+    case Map.get(map, key) do
+      nil -> Map.put(map, key, default)
+      _value -> map
+    end
   end
 
   defp find_descendents(nodes, parent_id) do

--- a/valentine/lib/valentine/mcp/tools/documents.ex
+++ b/valentine/lib/valentine/mcp/tools/documents.ex
@@ -116,6 +116,8 @@ defmodule Valentine.MCP.Tools.Documents do
   end
 
   defp normalize_dfd_attrs(%{"nodes" => nodes} = attrs) when is_map(nodes) do
+    nodes = DataFlowDiagram.normalize_nodes(nodes)
+
     {nodes, positioned_node_ids} =
       nodes
       |> Map.keys()
@@ -134,10 +136,23 @@ defmodule Valentine.MCP.Tools.Documents do
         end
       end)
 
-    {Map.put(attrs, "nodes", nodes), %{auto_positioned_nodes: Enum.reverse(positioned_node_ids)}}
+    attrs =
+      attrs
+      |> Map.put("nodes", nodes)
+      |> normalize_dfd_edges()
+
+    {attrs, %{auto_positioned_nodes: Enum.reverse(positioned_node_ids)}}
   end
 
-  defp normalize_dfd_attrs(attrs), do: {attrs, %{auto_positioned_nodes: []}}
+  defp normalize_dfd_attrs(attrs) do
+    {normalize_dfd_edges(attrs), %{auto_positioned_nodes: []}}
+  end
+
+  defp normalize_dfd_edges(%{"edges" => edges} = attrs) when is_map(edges) do
+    Map.put(attrs, "edges", DataFlowDiagram.normalize_edges(edges))
+  end
+
+  defp normalize_dfd_edges(attrs), do: attrs
 
   defp validate_dfd_attrs(attrs, dfd) do
     effective_nodes = Map.get(attrs, "nodes", dfd.nodes)

--- a/valentine/lib/valentine_web/live/workspace_live/import/json_import.ex
+++ b/valentine/lib/valentine_web/live/workspace_live/import/json_import.ex
@@ -1,5 +1,6 @@
 defmodule ValentineWeb.WorkspaceLive.Import.JsonImport do
   alias Valentine.Composer
+  alias Valentine.Composer.DataFlowDiagram
   alias Valentine.Repo
 
   def build_workspace(data, owner) do
@@ -68,8 +69,13 @@ defmodule ValentineWeb.WorkspaceLive.Import.JsonImport do
   end
 
   defp create_data_flow_diagram(workspace_id, data, crosswalks) do
-    edges = get_in(data, ["data_flow_diagram", "edges"]) || %{}
-    nodes = get_in(data, ["data_flow_diagram", "nodes"]) || %{}
+    edges =
+      (get_in(data, ["data_flow_diagram", "edges"]) || %{})
+      |> DataFlowDiagram.normalize_edges()
+
+    nodes =
+      (get_in(data, ["data_flow_diagram", "nodes"]) || %{})
+      |> DataFlowDiagram.normalize_nodes()
 
     # For each node, replace any linked_threats with the corresponding threat ID from the crosswalk
     nodes =

--- a/valentine/test/valentine_web/controllers/api/mcp_controller_test.exs
+++ b/valentine/test/valentine_web/controllers/api/mcp_controller_test.exs
@@ -209,6 +209,10 @@ defmodule ValentineWeb.Api.MCPControllerTest do
 
     assert get_in(dfd, ["nodes", "app", "position"]) == %{"x" => 0, "y" => 0}
     assert get_in(dfd, ["nodes", "browser", "position"]) == %{"x" => 260, "y" => 0}
+    assert get_in(dfd, ["nodes", "app", "data", "linked_threats"]) == []
+    assert get_in(dfd, ["nodes", "browser", "data", "linked_threats"]) == []
+    assert get_in(dfd, ["edges", "browser_to_app", "data", "linked_threats"]) == []
+    assert get_in(dfd, ["edges", "browser_to_app", "data", "type"]) == "edge"
 
     assert %{
              "code" => "auto_positioned_nodes",

--- a/valentine/test/valentine_web/live/workspace/import/json_import_test.exs
+++ b/valentine/test/valentine_web/live/workspace/import/json_import_test.exs
@@ -162,6 +162,55 @@ defmodule ValentineWeb.WorkspaceLive.Import.JsonImportTest do
       assert {:ok, workspace} = JsonImport.build_workspace(minimal_data, "some owner")
       assert workspace.name == "Untitled Workspace"
     end
+
+    test "imports MCP generated DFDs with missing optional metadata" do
+      data = %{
+        "name" => "Sparse DFD Workspace",
+        "application_information" => %{},
+        "architecture" => %{},
+        "data_flow_diagram" => %{
+          "nodes" => %{
+            "browser" => %{
+              "data" => %{
+                "id" => "browser",
+                "label" => "Browser",
+                "type" => "actor"
+              },
+              "position" => %{"x" => 0, "y" => 0}
+            },
+            "app" => %{
+              "data" => %{
+                "id" => "app",
+                "label" => "Phoenix App",
+                "type" => "process"
+              },
+              "position" => %{"x" => 260, "y" => 0}
+            }
+          },
+          "edges" => %{
+            "browser_to_app" => %{
+              "data" => %{
+                "id" => "browser_to_app",
+                "source" => "browser",
+                "target" => "app",
+                "label" => "HTTPS"
+              }
+            }
+          }
+        },
+        "assumptions" => [],
+        "mitigations" => [],
+        "threats" => []
+      }
+
+      assert {:ok, workspace} = JsonImport.build_workspace(data, "some owner")
+
+      dfd = Repo.get_by(Composer.DataFlowDiagram, workspace_id: workspace.id)
+      assert get_in(dfd.nodes, ["app", "data", "linked_threats"]) == []
+      assert get_in(dfd.nodes, ["browser", "data", "linked_threats"]) == []
+      assert get_in(dfd.edges, ["browser_to_app", "data", "linked_threats"]) == []
+      assert get_in(dfd.edges, ["browser_to_app", "data", "type"]) == "edge"
+    end
   end
 
   describe "process_json_file/1" do


### PR DESCRIPTION
This pull request improves the robustness and consistency of Data Flow Diagram (DFD) imports and normalization across the codebase. It introduces default values for missing optional metadata in DFD nodes and edges, ensures these defaults are applied during both document normalization and JSON import, and adds comprehensive tests for these scenarios.

**DFD normalization and default handling:**
* Introduced `@node_data_defaults` and `@edge_data_defaults` in `DataFlowDiagram`, and implemented `normalize_nodes/edges` and `normalize_node/edge` functions to ensure all nodes and edges have required optional metadata fields with sensible defaults. [[1]](diffhunk://#diff-a45a3945d99355d7d02a36e71906ea7df12cab979cb8563570a69189c99bbfd8R9-R27) [[2]](diffhunk://#diff-a45a3945d99355d7d02a36e71906ea7df12cab979cb8563570a69189c99bbfd8R189-R214) [[3]](diffhunk://#diff-a45a3945d99355d7d02a36e71906ea7df12cab979cb8563570a69189c99bbfd8R640-R652)
* Updated `normalize_dfd_attrs` and added `normalize_dfd_edges` in `Documents` to call these normalization functions, ensuring that DFDs saved via the MCP tool always include the expected metadata structure. [[1]](diffhunk://#diff-d24ed8e736481d4f153794dacfd32f061ee8af4bb3ee771f79359d2cc05d5934R119-R120) [[2]](diffhunk://#diff-d24ed8e736481d4f153794dacfd32f061ee8af4bb3ee771f79359d2cc05d5934L137-R155)

**DFD import improvements:**
* Modified the JSON import logic to normalize nodes and edges using the new functions, guaranteeing consistent data structure even when optional fields are missing from imported DFDs. [[1]](diffhunk://#diff-c2c9655d397ab5752315371915489caf19978ddc16b92669adfb7ab87e794054R3) [[2]](diffhunk://#diff-c2c9655d397ab5752315371915489caf19978ddc16b92669adfb7ab87e794054L71-R78)

**Testing enhancements:**
* Added and expanded tests to verify that DFD nodes and edges are correctly populated with default values for optional metadata fields, both in controller and import tests. [[1]](diffhunk://#diff-8e1142a8430d75e4d577cc24fa869c92e416530ebef2e024f53008ebcf6a1fa8R212-R215) [[2]](diffhunk://#diff-0013f5dab3e9d9930128de65408bae402aad0a0b3bba1c70d721b5a16316068cR165-R213)