### PR TITLE
Add cloud vendor tags feature

### DIFF
--- a/valentine/lib/valentine/composer/workspace.ex
+++ b/valentine/lib/valentine/composer/workspace.ex
@@ -12,6 +12,7 @@ defmodule Valentine.Composer.Workspace do
              :name,
              :cloud_profile,
              :cloud_profile_type,
+             :cloud_vendors,
              :url,
              :max_threat_level,
              :owner,
@@ -25,6 +26,7 @@ defmodule Valentine.Composer.Workspace do
     field :name, :string
     field :cloud_profile, :string
     field :cloud_profile_type, :string
+    field :cloud_vendors, {:array, :string}, default: []
     field :url, :string
     field :max_threat_level, Ecto.Enum, values: @td_levels
 
@@ -57,18 +59,84 @@ defmodule Valentine.Composer.Workspace do
 
   @doc false
   def changeset(workspace, attrs) do
+    attrs = normalize_cloud_vendors(attrs)
+
     workspace
     |> cast(attrs, [
       :name,
       :cloud_profile,
       :cloud_profile_type,
+      :cloud_vendors,
       :url,
       :max_threat_level,
       :owner,
       :permissions
     ])
+    |> validate_subset(:cloud_vendors, cloud_vendor_values())
     |> validate_required([:name, :owner, :permissions])
   end
+
+  def cloud_vendor_options do
+    [
+      {"AWS", "aws"},
+      {"Azure", "azure"},
+      {"Google Cloud", "google_cloud"}
+    ]
+  end
+
+  def cloud_vendor_values, do: Enum.map(cloud_vendor_options(), &elem(&1, 1))
+
+  def cloud_vendor_label("aws"), do: "AWS"
+  def cloud_vendor_label("azure"), do: "Azure"
+  def cloud_vendor_label("google_cloud"), do: "Google Cloud"
+  def cloud_vendor_label(value), do: value
+
+  def cloud_vendor_labels(vendors) when is_list(vendors) do
+    vendors
+    |> Enum.map(&cloud_vendor_label/1)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  def cloud_vendor_labels(_), do: []
+
+  def cloud_vendor_scope_label(vendors) do
+    case cloud_vendor_labels(vendors) do
+      [] -> "None selected"
+      [vendor] -> vendor
+      vendors -> "Hybrid: #{Enum.join(vendors, ", ")}"
+    end
+  end
+
+  defp normalize_cloud_vendors(attrs) when is_map(attrs) do
+    cond do
+      Map.has_key?(attrs, :cloud_vendors) ->
+        Map.put(attrs, :cloud_vendors, normalize_cloud_vendor_values(attrs[:cloud_vendors]))
+
+      Map.has_key?(attrs, "cloud_vendors") ->
+        Map.put(attrs, "cloud_vendors", normalize_cloud_vendor_values(attrs["cloud_vendors"]))
+
+      true ->
+        attrs
+    end
+  end
+
+  defp normalize_cloud_vendors(attrs), do: attrs
+
+  defp normalize_cloud_vendor_values(values) when is_list(values) do
+    values
+    |> Enum.map(&to_string/1)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.uniq()
+  end
+
+  defp normalize_cloud_vendor_values(value) when is_binary(value) do
+    value
+    |> String.split(",", trim: true)
+    |> normalize_cloud_vendor_values()
+  end
+
+  defp normalize_cloud_vendor_values(_), do: []
 
   def check_workspace_permissions(workspace, identity) do
     case workspace.owner do

--- a/valentine/lib/valentine/mcp/registry.ex
+++ b/valentine/lib/valentine/mcp/registry.ex
@@ -95,6 +95,12 @@ defmodule Valentine.MCP.Registry do
           name: string("Workspace display name."),
           cloud_profile: string("Optional cloud profile name or identifier."),
           cloud_profile_type: string("Optional cloud profile type."),
+          cloud_vendors: %{
+            type: "array",
+            items: %{type: "string"},
+            description:
+              "Optional cloud vendors associated with the workspace. Supported values: aws, azure, google_cloud."
+          },
           url: string("Optional application URL."),
           max_threat_level: string("Optional deliberate threat level, such as td3 or td4.")
         }),

--- a/valentine/lib/valentine/mcp/tools/workspace.ex
+++ b/valentine/lib/valentine/mcp/tools/workspace.ex
@@ -4,7 +4,14 @@ defmodule Valentine.MCP.Tools.Workspace do
   alias Valentine.Composer
   alias ValentineWeb.Workspace.Json, as: WorkspaceJson
 
-  @update_fields ["name", "cloud_profile", "cloud_profile_type", "url", "max_threat_level"]
+  @update_fields [
+    "name",
+    "cloud_profile",
+    "cloud_profile_type",
+    "cloud_vendors",
+    "url",
+    "max_threat_level"
+  ]
 
   @export_preloads [
     :application_information,

--- a/valentine/lib/valentine/repo_analysis.ex
+++ b/valentine/lib/valentine/repo_analysis.ex
@@ -405,6 +405,7 @@ defmodule Valentine.RepoAnalysis do
       "cloud_profile" => Map.get(attrs, "cloud_profile") || Map.get(attrs, :cloud_profile),
       "cloud_profile_type" =>
         Map.get(attrs, "cloud_profile_type") || Map.get(attrs, :cloud_profile_type),
+      "cloud_vendors" => Map.get(attrs, "cloud_vendors") || Map.get(attrs, :cloud_vendors) || [],
       "url" => github_url,
       "owner" => owner
     }

--- a/valentine/lib/valentine_web/controllers/workspace/json.ex
+++ b/valentine/lib/valentine_web/controllers/workspace/json.ex
@@ -3,6 +3,9 @@ defmodule ValentineWeb.Workspace.Json do
     %{
       workspace: %{
         name: workspace.name,
+        cloud_profile: workspace.cloud_profile,
+        cloud_profile_type: workspace.cloud_profile_type,
+        cloud_vendors: workspace.cloud_vendors,
         application_information: %{
           content: get_in(workspace.application_information.content)
         },

--- a/valentine/lib/valentine_web/live/workspace_live/form_component.ex
+++ b/valentine/lib/valentine_web/live/workspace_live/form_component.ex
@@ -4,6 +4,7 @@ defmodule ValentineWeb.WorkspaceLive.FormComponent do
 
   alias Valentine.Composer
   alias Valentine.Composer.DeliberateThreatLevel
+  alias Valentine.Composer.Workspace
 
   @impl true
   def render(assigns) do
@@ -74,6 +75,28 @@ defmodule ValentineWeb.WorkspaceLive.FormComponent do
               selected={@changeset.changes[:cloud_profile_type] || @workspace.cloud_profile_type}
               is_form_control
             />
+
+            <div class="FormControl mt-2">
+              <label class="FormControl-label">{gettext("Cloud Vendors")}</label>
+              <input type="hidden" name="workspace[cloud_vendors][]" value="" />
+              <%= for {label, value} <- Workspace.cloud_vendor_options() do %>
+                <div class="FormControl-checkbox-wrap">
+                  <input
+                    id={"workspace_cloud_vendor_#{value}"}
+                    type="checkbox"
+                    name="workspace[cloud_vendors][]"
+                    value={value}
+                    checked={value in selected_cloud_vendors(@changeset, @workspace)}
+                    class="FormControl-checkbox"
+                  />
+                  <span class="FormControl-checkbox-labelWrap">
+                    <label class="FormControl-label" for={"workspace_cloud_vendor_#{value}"}>
+                      {label}
+                    </label>
+                  </span>
+                </div>
+              <% end %>
+            </div>
 
             <.text_input
               form={f}
@@ -170,5 +193,9 @@ defmodule ValentineWeb.WorkspaceLive.FormComponent do
 
   defp max_threat_level_options do
     Enum.map(DeliberateThreatLevel.options(), fn {label, value} -> [key: label, value: value] end)
+  end
+
+  defp selected_cloud_vendors(changeset, workspace) do
+    changeset.changes[:cloud_vendors] || workspace.cloud_vendors || []
   end
 end

--- a/valentine/lib/valentine_web/live/workspace_live/github_import_component.ex
+++ b/valentine/lib/valentine_web/live/workspace_live/github_import_component.ex
@@ -5,13 +5,15 @@ defmodule ValentineWeb.WorkspaceLive.GitHubImportComponent do
   import Phoenix.HTML.Form, only: [input_value: 2]
 
   alias Ecto.Changeset
+  alias Valentine.Composer.Workspace
   alias Valentine.RepoAnalysis
 
   @form_types %{
     github_url: :string,
     name: :string,
     cloud_profile: :string,
-    cloud_profile_type: :string
+    cloud_profile_type: :string,
+    cloud_vendors: {:array, :string}
   }
 
   @impl true
@@ -84,6 +86,28 @@ defmodule ValentineWeb.WorkspaceLive.GitHubImportComponent do
               selected={input_value(f, :cloud_profile_type)}
               is_form_control
             />
+
+            <div class="FormControl mt-2">
+              <label class="FormControl-label">{gettext("Cloud Vendors")}</label>
+              <input type="hidden" name="import[cloud_vendors][]" value="" />
+              <%= for {label, value} <- Workspace.cloud_vendor_options() do %>
+                <div class="FormControl-checkbox-wrap">
+                  <input
+                    id={"import_cloud_vendor_#{value}"}
+                    type="checkbox"
+                    name="import[cloud_vendors][]"
+                    value={value}
+                    checked={value in selected_cloud_vendors(f)}
+                    class="FormControl-checkbox"
+                  />
+                  <span class="FormControl-checkbox-labelWrap">
+                    <label class="FormControl-label" for={"import_cloud_vendor_#{value}"}>
+                      {label}
+                    </label>
+                  </span>
+                </div>
+              <% end %>
+            </div>
 
             <div :if={@error} class="FormControl-inlineValidation FormControl-inlineValidation--error">
               {@error}
@@ -182,8 +206,13 @@ defmodule ValentineWeb.WorkspaceLive.GitHubImportComponent do
       "github_url" => "",
       "name" => "",
       "cloud_profile" => "",
-      "cloud_profile_type" => ""
+      "cloud_profile_type" => "",
+      "cloud_vendors" => []
     }
+  end
+
+  defp selected_cloud_vendors(form) do
+    input_value(form, :cloud_vendors) || []
   end
 
   defp format_changeset_error(changeset) do

--- a/valentine/lib/valentine_web/live/workspace_live/import/json_import.ex
+++ b/valentine/lib/valentine_web/live/workspace_live/import/json_import.ex
@@ -39,7 +39,14 @@ defmodule ValentineWeb.WorkspaceLive.Import.JsonImport do
 
   defp create_base_workspace(data, owner) do
     name = get_in(data, ["name"]) || "Untitled Workspace"
-    Composer.create_workspace(%{name: name, owner: owner})
+
+    Composer.create_workspace(%{
+      name: name,
+      owner: owner,
+      cloud_profile: get_in(data, ["cloud_profile"]),
+      cloud_profile_type: get_in(data, ["cloud_profile_type"]),
+      cloud_vendors: get_in(data, ["cloud_vendors"]) || []
+    })
   end
 
   defp create_application_info(workspace_id, data) do

--- a/valentine/lib/valentine_web/live/workspace_live/show.html.heex
+++ b/valentine/lib/valentine_web/live/workspace_live/show.html.heex
@@ -287,6 +287,11 @@
           <div class="f3">{@workspace.name}</div>
           <div class="f5 mt-1">{gettext("Profile")}: {@workspace.cloud_profile}</div>
           <div class="f5 mt-1">{gettext("Type")}: {@workspace.cloud_profile_type}</div>
+          <div class="f5 mt-1">
+            {gettext("Vendors")}: {Valentine.Composer.Workspace.cloud_vendor_scope_label(
+              @workspace.cloud_vendors
+            )}
+          </div>
           <table class="summary">
             <tr>
               <td>{gettext("Total threats")}</td>

--- a/valentine/priv/repo/migrations/20260505120000_add_cloud_vendors_to_workspaces.exs
+++ b/valentine/priv/repo/migrations/20260505120000_add_cloud_vendors_to_workspaces.exs
@@ -1,0 +1,9 @@
+defmodule Valentine.Repo.Migrations.AddCloudVendorsToWorkspaces do
+  use Ecto.Migration
+
+  def change do
+    alter table(:workspaces) do
+      add :cloud_vendors, {:array, :string}, null: false, default: []
+    end
+  end
+end

--- a/valentine/test/support/fixtures/composer_fixtures.ex
+++ b/valentine/test/support/fixtures/composer_fixtures.ex
@@ -22,6 +22,7 @@ defmodule Valentine.ComposerFixtures do
         name: "some name",
         cloud_profile: "some cloud_profile",
         cloud_profile_type: "some cloud_profile_type",
+        cloud_vendors: ["aws"],
         url: "some url",
         max_threat_level: :td4,
         owner: "some owner",

--- a/valentine/test/valentine/composer_test.exs
+++ b/valentine/test/valentine/composer_test.exs
@@ -39,6 +39,7 @@ defmodule Valentine.ComposerTest do
         name: "some name",
         cloud_profile: "some cloud_profile",
         cloud_profile_type: "some cloud_profile_type",
+        cloud_vendors: ["aws", "azure"],
         url: "some url",
         max_threat_level: :td4,
         owner: "some owner",
@@ -49,6 +50,7 @@ defmodule Valentine.ComposerTest do
       assert workspace.name == "some name"
       assert workspace.cloud_profile == "some cloud_profile"
       assert workspace.cloud_profile_type == "some cloud_profile_type"
+      assert workspace.cloud_vendors == ["aws", "azure"]
       assert workspace.url == "some url"
       assert workspace.max_threat_level == :td4
       assert workspace.owner == "some owner"
@@ -66,6 +68,7 @@ defmodule Valentine.ComposerTest do
         name: "some updated name",
         cloud_profile: "some updated cloud_profile",
         cloud_profile_type: "some updated cloud_profile_type",
+        cloud_vendors: ["google_cloud"],
         url: "some updated url",
         max_threat_level: :td6,
         owner: "some updated owner",
@@ -76,6 +79,7 @@ defmodule Valentine.ComposerTest do
       assert workspace.name == "some updated name"
       assert workspace.cloud_profile == "some updated cloud_profile"
       assert workspace.cloud_profile_type == "some updated cloud_profile_type"
+      assert workspace.cloud_vendors == ["google_cloud"]
       assert workspace.url == "some updated url"
       assert workspace.max_threat_level == :td6
       assert workspace.owner == "some updated owner"
@@ -89,6 +93,15 @@ defmodule Valentine.ComposerTest do
                Composer.update_workspace(workspace, %{max_threat_level: :td10})
 
       assert "is invalid" in errors_on(changeset).max_threat_level
+    end
+
+    test "update_workspace/2 rejects unsupported cloud vendors" do
+      workspace = workspace_fixture()
+
+      assert {:error, %Ecto.Changeset{} = changeset} =
+               Composer.update_workspace(workspace, %{cloud_vendors: ["digital_ocean"]})
+
+      assert "has an invalid entry" in errors_on(changeset).cloud_vendors
     end
 
     test "update_workspace/2 with invalid data returns error changeset" do

--- a/valentine/test/valentine/repo_analysis_test.exs
+++ b/valentine/test/valentine/repo_analysis_test.exs
@@ -34,7 +34,8 @@ defmodule Valentine.RepoAnalysisTest do
         "github_url" => "https://github.com/example/valentine-service",
         "name" => "Imported workspace",
         "cloud_profile" => "CCCS Low Profile for Cloud",
-        "cloud_profile_type" => "CSP Full Stack"
+        "cloud_profile_type" => "CSP Full Stack",
+        "cloud_vendors" => ["aws", "google_cloud"]
       }
 
       assert {:ok, %{workspace: workspace, repo_analysis_agent: repo_analysis_agent}} =
@@ -45,6 +46,7 @@ defmodule Valentine.RepoAnalysisTest do
       assert workspace.owner == "owner-1"
       assert workspace.cloud_profile == "CCCS Low Profile for Cloud"
       assert workspace.cloud_profile_type == "CSP Full Stack"
+      assert workspace.cloud_vendors == ["aws", "google_cloud"]
 
       assert repo_analysis_agent.workspace_id == workspace.id
       assert repo_analysis_agent.owner == "owner-1"

--- a/valentine/test/valentine_web/controllers/api/workspace_controller_test.exs
+++ b/valentine/test/valentine_web/controllers/api/workspace_controller_test.exs
@@ -17,6 +17,7 @@ defmodule ValentineWeb.Api.WorkspaceControllerTest do
                "owner" => api_key.owner,
                "cloud_profile" => workspace.cloud_profile,
                "cloud_profile_type" => workspace.cloud_profile_type,
+               "cloud_vendors" => workspace.cloud_vendors,
                "max_threat_level" => Atom.to_string(workspace.max_threat_level),
                "permissions" => workspace.permissions,
                "url" => workspace.url

--- a/valentine/test/valentine_web/live/workspace/form_component_test.exs
+++ b/valentine/test/valentine_web/live/workspace/form_component_test.exs
@@ -23,6 +23,10 @@ defmodule ValentineWeb.WorkspaceLive.FormComponentTest do
     test "renders the form with an Edit title if workspace exists", %{assigns: assigns} do
       html = render_component(FormComponent, assigns)
       assert html =~ "Edit Workspace"
+      assert html =~ "Cloud Vendors"
+      assert html =~ "AWS"
+      assert html =~ "Azure"
+      assert html =~ "Google Cloud"
       assert html =~ "Maximum Deliberate Threat Level"
       assert html =~ "Td4 - Organized Criminal Group"
     end
@@ -146,6 +150,7 @@ defmodule ValentineWeb.WorkspaceLive.FormComponentTest do
           %{
             "workspace" => %{
               "name" => "some name",
+              "cloud_vendors" => ["azure", "google_cloud"],
               "max_threat_level" => "td6"
             }
           },
@@ -155,6 +160,11 @@ defmodule ValentineWeb.WorkspaceLive.FormComponentTest do
       assert socket.assigns.flash["info"] == "Workspace created successfully"
       assert socket.assigns.patch == socket.assigns.patch
       assert Enum.any?(Composer.list_workspaces(), &(&1.max_threat_level == :td6))
+
+      assert Enum.any?(
+               Composer.list_workspaces(),
+               &(&1.cloud_vendors == ["azure", "google_cloud"])
+             )
     end
 
     test "returns a changeset for a new workspace", %{socket: socket} do

--- a/valentine/test/valentine_web/live/workspace/import/json_import_test.exs
+++ b/valentine/test/valentine_web/live/workspace/import/json_import_test.exs
@@ -9,6 +9,9 @@ defmodule ValentineWeb.WorkspaceLive.Import.JsonImportTest do
   {
     "workspace": {
       "name": "Test Application",
+      "cloud_profile": "CCCS Low Profile for Cloud",
+      "cloud_profile_type": "CSP Full Stack",
+      "cloud_vendors": ["aws", "azure"],
       "application_information": {
         "content": "This is a test description"
       },
@@ -94,6 +97,9 @@ defmodule ValentineWeb.WorkspaceLive.Import.JsonImportTest do
 
       # Verify workspace
       assert workspace.name == "Test Application"
+      assert workspace.cloud_profile == "CCCS Low Profile for Cloud"
+      assert workspace.cloud_profile_type == "CSP Full Stack"
+      assert workspace.cloud_vendors == ["aws", "azure"]
 
       # Verify application info
       app_info = Repo.get_by(Composer.ApplicationInformation, workspace_id: workspace.id)

--- a/valentine/test/valentine_web/live/workspace/show_view_test.exs
+++ b/valentine/test/valentine_web/live/workspace/show_view_test.exs
@@ -63,6 +63,15 @@ defmodule ValentineWeb.WorkspaceLive.ShowViewTest do
       assert html =~ workspace.cloud_profile_type
     end
 
+    test "display workspace cloud vendors", %{conn: conn, workspace: workspace} do
+      conn = conn |> Phoenix.ConnTest.init_test_session(%{user_id: "some owner"})
+
+      {:ok, _index_live, html} = live(conn, ~p"/workspaces/#{workspace.id}")
+
+      assert html =~ "Vendors"
+      assert html =~ "AWS"
+    end
+
     test "display mitigation status", %{conn: conn, mitigation: mitigation} do
       conn = conn |> Phoenix.ConnTest.init_test_session(%{user_id: "some owner"})
 


### PR DESCRIPTION
Closes #48 

This pull request adds support for associating multiple cloud vendors with a workspace. It introduces a new `cloud_vendors` field to the workspace model, updates forms and APIs to allow users to select vendors, and ensures validation and normalization of vendor values. Test coverage and documentation are also updated to reflect these changes.

**Workspace Model and Schema Updates**
- Added a new `cloud_vendors` field (array of strings) to the `Workspace` schema, including migration, default value, and validation to ensure only supported vendors (`aws`, `azure`, `google_cloud`) are accepted. Helper functions for vendor options, labels, and normalization were also introduced. [[1]](diffhunk://#diff-4820cd86e151c304be0c8e129e3516ca4cf84f62223705c9e19215ebc1891e5eR15) [[2]](diffhunk://#diff-4820cd86e151c304be0c8e129e3516ca4cf84f62223705c9e19215ebc1891e5eR29) [[3]](diffhunk://#diff-4820cd86e151c304be0c8e129e3516ca4cf84f62223705c9e19215ebc1891e5eR62-R140) [[4]](diffhunk://#diff-d62fcb12ce7c6b0a7407b3a0b3c715eb67405c3ebeb73ef8592a42567a001639R1-R9)

**User Interface Enhancements**
- Updated the workspace creation and import forms to include checkboxes for selecting cloud vendors, with proper handling of selections and display of chosen vendors. [[1]](diffhunk://#diff-684bc40b7d00fa56b7a8699722d1cc5aeae89db4ee91e072f6d6a17aa0d99f87R7) [[2]](diffhunk://#diff-684bc40b7d00fa56b7a8699722d1cc5aeae89db4ee91e072f6d6a17aa0d99f87R79-R100) [[3]](diffhunk://#diff-684bc40b7d00fa56b7a8699722d1cc5aeae89db4ee91e072f6d6a17aa0d99f87R197-R200) [[4]](diffhunk://#diff-f549ed1fb4dc3ebdee1c4547968e4a8af78d8b84a903ff08f7e8a0de313224deR8-R16) [[5]](diffhunk://#diff-f549ed1fb4dc3ebdee1c4547968e4a8af78d8b84a903ff08f7e8a0de313224deR90-R111) [[6]](diffhunk://#diff-f549ed1fb4dc3ebdee1c4547968e4a8af78d8b84a903ff08f7e8a0de313224deL185-R217) [[7]](diffhunk://#diff-e6dab14013c8a238c521bde53b6d0df226112492105a1fe07c35bdc70395cc0aR290-R294)

**API and Data Flow Adjustments**
- Modified JSON serialization, API controllers, and registry schemas to support the new `cloud_vendors` field in workspace data structures. [[1]](diffhunk://#diff-67e891fda1d967be28396b636948c3a151d3e93c9ad75df6130007cbf989d6e5R6-R8) [[2]](diffhunk://#diff-6f06e8319fa3292ca9dc6e55609e3cfa4c144fdce9e05d1785f2ac76473226c9R98-R103) [[3]](diffhunk://#diff-cee96524b86eca58b9efc050052804cc893d67e9549e2ee1da1198f7d46b9f63R20) [[4]](diffhunk://#diff-2ec32d0bb2aab821b4355a4ec48a272c0f2d654d95740ac033b14c3f95fea4c8L7-R14) [[5]](diffhunk://#diff-4a52f00d48fbf26d5fa9e2dc60f69c36d7dcdb1b1bb1bde6b63b70ced220368cR408) [[6]](diffhunk://#diff-c2c9655d397ab5752315371915489caf19978ddc16b92669adfb7ab87e794054L42-R49)

**Test Coverage**
- Enhanced tests and fixtures to cover the new `cloud_vendors` field, including validation for unsupported vendors and UI rendering of vendor options. [[1]](diffhunk://#diff-c944294c0184ffcf28b5759448b23f3edb844cae5103008c4a7435d67eb6a4f4R25) [[2]](diffhunk://#diff-75ca021cf605d2884500a6a43f660c91d28aa07cebd14bfb223088fbf83d1f19R42) [[3]](diffhunk://#diff-75ca021cf605d2884500a6a43f660c91d28aa07cebd14bfb223088fbf83d1f19R53) [[4]](diffhunk://#diff-75ca021cf605d2884500a6a43f660c91d28aa07cebd14bfb223088fbf83d1f19R71) [[5]](diffhunk://#diff-75ca021cf605d2884500a6a43f660c91d28aa07cebd14bfb223088fbf83d1f19R82) [[6]](diffhunk://#diff-75ca021cf605d2884500a6a43f660c91d28aa07cebd14bfb223088fbf83d1f19R98-R106) [[7]](diffhunk://#diff-7d983d3f2382cc58f8851fc5826d55acc237171dde1532dd1ce88353f333500cL37-R38) [[8]](diffhunk://#diff-7d983d3f2382cc58f8851fc5826d55acc237171dde1532dd1ce88353f333500cR49) [[9]](diffhunk://#diff-0f0b2343e50801105b02e1b1b7729e3e9378c675290fba8eaf4bf7f74bcf9899R26-R29) [[10]](diffhunk://#diff-0f0b2343e50801105b02e1b1b7729e3e9378c675290fba8eaf4bf7f74bcf9899R153) [[11]](diffhunk://#diff-0f0b2343e50801105b02e1b1b7729e3e9378c675290fba8eaf4bf7f74bcf9899R163-R167)

**Internal Logic and Helpers**
- Added normalization and utility functions to handle `cloud_vendors` input from various sources, ensuring consistent storage and display.

Let me know if you want to walk through any part of the code or logic in more detail!