### PR TITLE
feat: add workspace api key isolation

### DIFF
--- a/valentine/lib/valentine/composer.ex
+++ b/valentine/lib/valentine/composer.ex
@@ -1997,6 +1997,29 @@ defmodule Valentine.Composer do
   end
 
   @doc """
+  Creates an API key scoped to a workspace owned by the given identity.
+
+  Only the label is accepted from `attrs`. The workspace, owner, and initial
+  status are derived from trusted server-side values.
+  """
+  def create_api_key_for_workspace(
+        %Workspace{owner: owner} = workspace,
+        owner,
+        attrs
+      )
+      when is_binary(owner) and is_map(attrs) do
+    create_api_key(%{
+      label: Map.get(attrs, "label", Map.get(attrs, :label)),
+      owner: owner,
+      status: :active,
+      workspace_id: workspace.id
+    })
+  end
+
+  def create_api_key_for_workspace(%Workspace{}, _identity, _attrs),
+    do: {:error, :unauthorized}
+
+  @doc """
   Updates a api_key.
 
   ## Examples

--- a/valentine/lib/valentine_web/live/workspace_live/api_key/components/api_key_component.ex
+++ b/valentine/lib/valentine_web/live/workspace_live/api_key/components/api_key_component.ex
@@ -34,9 +34,6 @@ defmodule ValentineWeb.WorkspaceLive.ApiKey.Components.ApiKeyComponent do
               is_full_width
               is_form_control
             />
-            <input type="hidden" value={@api_key.workspace_id} name="api_key[workspace_id]" />
-            <input type="hidden" value={:active} name="api_key[status]" />
-            <input type="hidden" value={@current_user} name="api_key[owner]" />
           </:body>
           <:footer>
             <.button is_primary is_submit phx-disable-with={gettext("Saving...")}>
@@ -62,7 +59,12 @@ defmodule ValentineWeb.WorkspaceLive.ApiKey.Components.ApiKeyComponent do
 
   @impl true
   def handle_event("validate", %{"api_key" => api_key_params}, socket) do
-    changeset = Composer.change_api_key(socket.assigns.api_key, api_key_params)
+    changeset =
+      Composer.change_api_key(
+        socket.assigns.api_key,
+        trusted_api_key_params(socket, api_key_params)
+      )
+
     {:noreply, assign(socket, :changeset, changeset)}
   end
 
@@ -72,7 +74,11 @@ defmodule ValentineWeb.WorkspaceLive.ApiKey.Components.ApiKeyComponent do
   end
 
   defp save_api_key(socket, :generate, api_key_params) do
-    case Composer.create_api_key(api_key_params) do
+    case Composer.create_api_key_for_workspace(
+           socket.assigns.workspace,
+           socket.assigns.current_user,
+           api_key_params
+         ) do
       {:ok, api_key} ->
         notify_parent({:saved, api_key})
 
@@ -91,7 +97,24 @@ defmodule ValentineWeb.WorkspaceLive.ApiKey.Components.ApiKeyComponent do
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, changeset: changeset)}
+
+      {:error, :unauthorized} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           gettext("Only workspace owners can generate API keys")
+         )}
     end
+  end
+
+  defp trusted_api_key_params(socket, api_key_params) do
+    %{
+      label: Map.get(api_key_params, "label", Map.get(api_key_params, :label)),
+      owner: socket.assigns.current_user,
+      status: :active,
+      workspace_id: socket.assigns.workspace.id
+    }
   end
 
   defp notify_parent(msg), do: send(self(), {__MODULE__, msg})

--- a/valentine/test/valentine/composer_test.exs
+++ b/valentine/test/valentine/composer_test.exs
@@ -1524,6 +1524,44 @@ defmodule Valentine.ComposerTest do
       assert {:error, %Ecto.Changeset{}} = Composer.create_api_key(@invalid_attrs)
     end
 
+    test "create_api_key_for_workspace/3 derives protected fields from trusted values" do
+      workspace = workspace_fixture(%{owner: "workspace.owner@localhost"})
+      other_workspace = workspace_fixture(%{owner: "other.owner@localhost"})
+
+      untrusted_attrs = %{
+        "label" => "CI integration",
+        "owner" => other_workspace.owner,
+        "status" => "revoked",
+        "workspace_id" => other_workspace.id
+      }
+
+      assert {:ok, %ApiKey{} = api_key} =
+               Composer.create_api_key_for_workspace(
+                 workspace,
+                 workspace.owner,
+                 untrusted_attrs
+               )
+
+      assert api_key.label == "CI integration"
+      assert api_key.owner == workspace.owner
+      assert api_key.status == :active
+      assert api_key.workspace_id == workspace.id
+      assert Composer.list_api_keys_by_workspace(other_workspace.id) == []
+    end
+
+    test "create_api_key_for_workspace/3 rejects non-owners" do
+      workspace = workspace_fixture(%{owner: "workspace.owner@localhost"})
+
+      assert {:error, :unauthorized} =
+               Composer.create_api_key_for_workspace(
+                 workspace,
+                 "collaborator@localhost",
+                 %{"label" => "Unauthorized key"}
+               )
+
+      assert Composer.list_api_keys_by_workspace(workspace.id) == []
+    end
+
     test "update_api_key/2 with valid data updates the api_key" do
       api_key = api_key_fixture()
 

--- a/valentine/test/valentine_web/live/workspace/api_key/components/api_component_test.exs
+++ b/valentine/test/valentine_web/live/workspace/api_key/components/api_component_test.exs
@@ -39,6 +39,9 @@ defmodule ValentineWeb.WorkspaceLive.ApiKey.Components.ApiKeyComponentTest do
 
       html = render_component(ApiKeyComponent, assigns)
       assert html =~ "Generate API Key"
+      refute html =~ "api_key[workspace_id]"
+      refute html =~ "api_key[owner]"
+      refute html =~ "api_key[status]"
     end
   end
 
@@ -46,29 +49,30 @@ defmodule ValentineWeb.WorkspaceLive.ApiKey.Components.ApiKeyComponentTest do
     setup [:create_api_key]
 
     test "validates the form invalid if fields are missing", %{socket: socket} do
-      socket =
-        Map.put(socket, :assigns, %{
-          __changed__: %{},
-          api_key: %Valentine.Composer.ApiKey{
-            workspace_id: "00000000-0000-0000-0000-000000000000"
-          }
-        })
-
       {:noreply, socket} =
-        ApiKeyComponent.handle_event("validate", %{"api_key" => %{}}, socket)
+        ApiKeyComponent.handle_event(
+          "validate",
+          %{"api_key" => %{"label" => nil}},
+          socket
+        )
 
       assert socket.assigns.changeset.valid? == false
     end
 
     test "validates the form valid if nothing is missing", %{socket: socket} do
       {:noreply, socket} =
-        ApiKeyComponent.handle_event("validate", %{"api_key" => %{}}, socket)
+        ApiKeyComponent.handle_event(
+          "validate",
+          %{"api_key" => %{"label" => "some label"}},
+          socket
+        )
 
       assert socket.assigns.changeset.valid? == true
     end
 
-    test "saves a new api_key", %{assigns: assigns, socket: socket} do
+    test "saves a new api_key using trusted protected fields", %{socket: socket} do
       workspace = workspace_fixture()
+      other_workspace = workspace_fixture(%{owner: "other.owner@localhost"})
 
       socket =
         Map.put(socket, :assigns, %{
@@ -79,7 +83,8 @@ defmodule ValentineWeb.WorkspaceLive.ApiKey.Components.ApiKeyComponentTest do
           },
           current_user: workspace.owner,
           flash: %{},
-          patch: "/workspace/00000000-0000-0000-0000-000000000000/api_keys"
+          patch: "/workspace/00000000-0000-0000-0000-000000000000/api_keys",
+          workspace: workspace
         })
 
       {:noreply, socket} =
@@ -88,9 +93,9 @@ defmodule ValentineWeb.WorkspaceLive.ApiKey.Components.ApiKeyComponentTest do
           %{
             "api_key" => %{
               label: "some label",
-              owner: assigns.current_user,
-              status: "active",
-              workspace_id: assigns.api_key.workspace_id
+              owner: other_workspace.owner,
+              status: "revoked",
+              workspace_id: other_workspace.id
             }
           },
           socket
@@ -98,9 +103,21 @@ defmodule ValentineWeb.WorkspaceLive.ApiKey.Components.ApiKeyComponentTest do
 
       assert socket.assigns.flash["info"] == "API Key created successfully"
       assert socket.assigns.patch == socket.assigns.patch
+
+      api_key =
+        workspace.id
+        |> Valentine.Composer.list_api_keys_by_workspace()
+        |> Enum.find(&(&1.label == "some label"))
+
+      assert api_key.owner == workspace.owner
+      assert api_key.status == :active
+      assert api_key.workspace_id == workspace.id
+      assert Valentine.Composer.list_api_keys_by_workspace(other_workspace.id) == []
     end
 
     test "returns a changeset for a new api_key", %{socket: socket} do
+      workspace = socket.assigns.workspace
+
       socket =
         Map.put(socket, :assigns, %{
           __changed__: %{},
@@ -108,8 +125,10 @@ defmodule ValentineWeb.WorkspaceLive.ApiKey.Components.ApiKeyComponentTest do
           api_key: %Valentine.Composer.ApiKey{
             workspace_id: "00000000-0000-0000-0000-000000000000"
           },
+          current_user: workspace.owner,
           flash: %{},
-          patch: "/workspace/00000000-0000-0000-0000-000000000000/api_keys"
+          patch: "/workspace/00000000-0000-0000-0000-000000000000/api_keys",
+          workspace: workspace
         })
 
       {:noreply, socket} =
@@ -124,6 +143,33 @@ defmodule ValentineWeb.WorkspaceLive.ApiKey.Components.ApiKeyComponentTest do
         )
 
       assert socket.assigns.changeset.valid? == false
+    end
+
+    test "rejects API key creation by a non-owner", %{socket: socket} do
+      workspace = socket.assigns.workspace
+
+      socket =
+        Map.put(
+          socket,
+          :assigns,
+          Map.merge(socket.assigns, %{
+            current_user: "collaborator@localhost",
+            flash: %{}
+          })
+        )
+
+      {:noreply, socket} =
+        ApiKeyComponent.handle_event(
+          "save",
+          %{"api_key" => %{"label" => "Unauthorized key"}},
+          socket
+        )
+
+      assert socket.assigns.flash["error"] ==
+               "Only workspace owners can generate API keys"
+
+      assert Valentine.Composer.list_api_keys_by_workspace(workspace.id)
+             |> Enum.all?(&(&1.label != "Unauthorized key"))
     end
   end
 end

--- a/valentine/test/valentine_web/live/workspace/api_key/index_view_test.exs
+++ b/valentine/test/valentine_web/live/workspace/api_key/index_view_test.exs
@@ -4,7 +4,9 @@ defmodule ValentineWeb.WorkspaceLive.ApiKey.IndexViewTest do
   import Phoenix.LiveViewTest
   import Valentine.ComposerFixtures
 
-  @create_attrs %{label: "some label", workspace_id: nil}
+  alias Valentine.Composer
+
+  @create_attrs %{label: "some label"}
 
   defp create_api_key(_) do
     api_key = api_key_fixture()
@@ -62,7 +64,7 @@ defmodule ValentineWeb.WorkspaceLive.ApiKey.IndexViewTest do
 
       assert index_live
              |> form("#api-keys-form",
-               api_key: %{@create_attrs | workspace_id: workspace_id}
+               api_key: @create_attrs
              )
              |> render_submit()
 
@@ -71,6 +73,42 @@ defmodule ValentineWeb.WorkspaceLive.ApiKey.IndexViewTest do
       html = render(index_live)
       assert html =~ "API Key created successfully"
       assert html =~ "some label"
+    end
+
+    test "ignores forged workspace, owner, and status fields", %{
+      conn: conn,
+      workspace_id: workspace_id
+    } do
+      workspace = Composer.get_workspace!(workspace_id)
+      other_workspace = workspace_fixture(%{owner: "other.owner@localhost"})
+      conn = Phoenix.ConnTest.init_test_session(conn, %{user_id: workspace.owner})
+
+      {:ok, index_live, _html} = live(conn, ~p"/workspaces/#{workspace.id}/api_keys")
+
+      index_live
+      |> element("#generate-api-key")
+      |> render_click()
+
+      index_live
+      |> element("#api-keys-form")
+      |> render_submit(%{
+        "api_key" => %{
+          "label" => "forged submission",
+          "owner" => other_workspace.owner,
+          "status" => "revoked",
+          "workspace_id" => other_workspace.id
+        }
+      })
+
+      api_key =
+        workspace.id
+        |> Composer.list_api_keys_by_workspace()
+        |> Enum.find(&(&1.label == "forged submission"))
+
+      assert api_key.owner == workspace.owner
+      assert api_key.status == :active
+      assert api_key.workspace_id == workspace.id
+      assert Composer.list_api_keys_by_workspace(other_workspace.id) == []
     end
 
     test "deletes api_key in listing", %{


### PR DESCRIPTION
This pull request strengthens the security of API key creation for workspaces by ensuring only workspace owners can generate keys, and that protected fields (such as owner, status, and workspace_id) cannot be forged via client input. All sensitive fields are now derived from trusted server-side values. The changes also update the UI and tests to reflect these security improvements.

**Security enhancements for API key creation:**

* Added `create_api_key_for_workspace/3` in `Valentine.Composer` to ensure API keys are created only by workspace owners, with protected fields (`owner`, `status`, `workspace_id`) derived from trusted server-side values. Attempts by non-owners are rejected.
* Updated the API key creation form (`ApiKeyComponent`) to remove hidden inputs for protected fields and to build the API key parameters on the server using trusted values. [[1]](diffhunk://#diff-a0d54aabc2bbe5b981e9098c4b5b4707dc5a689f0a9932330acf46389a2d901cL37-L39) [[2]](diffhunk://#diff-a0d54aabc2bbe5b981e9098c4b5b4707dc5a689f0a9932330acf46389a2d901cL65-R67) [[3]](diffhunk://#diff-a0d54aabc2bbe5b981e9098c4b5b4707dc5a689f0a9932330acf46389a2d901cL75-R81) [[4]](diffhunk://#diff-a0d54aabc2bbe5b981e9098c4b5b4707dc5a689f0a9932330acf46389a2d901cR100-R119)

**Test coverage and validation:**

* Added comprehensive tests in `ComposerTest`, `ApiKeyComponentTest`, and `IndexViewTest` to verify that:
  - Only workspace owners can create API keys.
  - Forged or manipulated input for protected fields is ignored.
  - Non-owners receive appropriate error messages and cannot create keys. [[1]](diffhunk://#diff-75ca021cf605d2884500a6a43f660c91d28aa07cebd14bfb223088fbf83d1f19R1527-R1564) [[2]](diffhunk://#diff-48f3d4250ba7bf2d6122c7b1a513852c62653edfce6602ee21f56305f147e1f5R42-R75) [[3]](diffhunk://#diff-48f3d4250ba7bf2d6122c7b1a513852c62653edfce6602ee21f56305f147e1f5L82-R87) [[4]](diffhunk://#diff-48f3d4250ba7bf2d6122c7b1a513852c62653edfce6602ee21f56305f147e1f5L91-R131) [[5]](diffhunk://#diff-48f3d4250ba7bf2d6122c7b1a513852c62653edfce6602ee21f56305f147e1f5R147-R173) [[6]](diffhunk://#diff-deaca2a6f1318f043561f7dbc0d0fdb2d92d865f2e392cef8ec3ea4a1e38a40eL7-R9) [[7]](diffhunk://#diff-deaca2a6f1318f043561f7dbc0d0fdb2d92d865f2e392cef8ec3ea4a1e38a40eL65-R67) [[8]](diffhunk://#diff-deaca2a6f1318f043561f7dbc0d0fdb2d92d865f2e392cef8ec3ea4a1e38a40eR78-R113)

These changes ensure that API key creation is both secure and robust against client-side tampering.