### PR TITLE
fix: path traversal

### DIFF
--- a/valentine/lib/valentine/repo_analysis/github.ex
+++ b/valentine/lib/valentine/repo_analysis/github.ex
@@ -155,10 +155,11 @@ defmodule Valentine.RepoAnalysis.GitHub do
   end
 
   defp tracked_files(clone_dir) do
-    {output, 0} = System.cmd("git", ["-C", clone_dir, "ls-files"], stderr_to_stdout: true)
+    {output, 0} =
+      System.cmd("git", ["-C", clone_dir, "ls-files", "-z"], stderr_to_stdout: true)
 
     output
-    |> String.split("\n", trim: true)
+    |> String.split("\0", trim: true)
     |> Enum.filter(&eligible_file?/1)
   end
 
@@ -197,17 +198,37 @@ defmodule Valentine.RepoAnalysis.GitHub do
   end
 
   defp read_document(clone_dir, relative_path, max_file_bytes) do
-    full_path = Path.join(clone_dir, relative_path)
+    with {:ok, full_path} <- safe_regular_file(clone_dir, relative_path, max_file_bytes),
+         {:ok, content} <- File.read(full_path) do
+      %{path: relative_path, content: content}
+    else
+      _ -> nil
+    end
+  end
 
-    case File.stat(full_path) do
-      {:ok, %{size: size}} when size <= max_file_bytes ->
-        case File.read(full_path) do
-          {:ok, content} -> %{path: relative_path, content: content}
-          _ -> nil
-        end
+  defp safe_regular_file(clone_dir, relative_path, max_file_bytes) do
+    path_parts = Path.split(relative_path)
 
-      _ ->
-        nil
+    with :relative <- Path.type(relative_path),
+         false <- Enum.any?(path_parts, &(&1 in [".", ".."])),
+         [_ | _] <- path_parts,
+         {:ok, full_path} <- walk_regular_path(Path.expand(clone_dir), path_parts),
+         {:ok, %{type: :regular, size: size}} when size <= max_file_bytes <-
+           File.lstat(full_path) do
+      {:ok, full_path}
+    else
+      _ -> :error
+    end
+  end
+
+  defp walk_regular_path(parent, [filename]), do: {:ok, Path.join(parent, filename)}
+
+  defp walk_regular_path(parent, [directory | rest]) do
+    path = Path.join(parent, directory)
+
+    case File.lstat(path) do
+      {:ok, %{type: :directory}} -> walk_regular_path(path, rest)
+      _ -> :error
     end
   end
 

--- a/valentine/test/valentine/repo_analysis/github_test.exs
+++ b/valentine/test/valentine/repo_analysis/github_test.exs
@@ -4,6 +4,53 @@ defmodule Valentine.RepoAnalysis.GitHubTest do
   alias Valentine.RepoAnalysis.GitHub
   alias Valentine.RepoAnalysis.GitHub.RepoRef
 
+  describe "build_snapshot/3" do
+    test "does not read tracked symbolic links to files outside the repository" do
+      temp_dir =
+        Path.join(
+          System.tmp_dir!(),
+          "repo-analysis-github-symlink-test-#{System.unique_integer([:positive])}"
+        )
+
+      clone_dir = Path.join(temp_dir, "repository")
+      secret_path = Path.join(temp_dir, "server-secret.txt")
+      secret = "server-only-secret-#{System.unique_integer([:positive])}"
+
+      File.mkdir_p!(clone_dir)
+      File.write!(secret_path, secret)
+      File.ln_s!(secret_path, Path.join(clone_dir, "README.md"))
+      initialize_git_index(clone_dir, "README.md")
+
+      on_exit(fn -> File.rm_rf(temp_dir) end)
+
+      {:ok, snapshot} = GitHub.build_snapshot(clone_dir, repo_ref(), snapshot_limits())
+
+      assert snapshot.documents == []
+      refute inspect(snapshot) =~ secret
+    end
+
+    test "reads tracked regular files" do
+      temp_dir =
+        Path.join(
+          System.tmp_dir!(),
+          "repo-analysis-github-regular-file-test-#{System.unique_integer([:positive])}"
+        )
+
+      clone_dir = Path.join(temp_dir, "repository")
+      File.mkdir_p!(clone_dir)
+      File.write!(Path.join(clone_dir, "README.md"), "public repository documentation")
+      initialize_git_index(clone_dir, "README.md")
+
+      on_exit(fn -> File.rm_rf(temp_dir) end)
+
+      {:ok, snapshot} = GitHub.build_snapshot(clone_dir, repo_ref(), snapshot_limits())
+
+      assert snapshot.documents == [
+               %{path: "README.md", content: "public repository documentation"}
+             ]
+    end
+  end
+
   describe "clone/3" do
     test "removes the clone directory when the clone command times out" do
       temp_dir =
@@ -96,5 +143,29 @@ defmodule Valentine.RepoAnalysis.GitHubTest do
 
       refute File.exists?(Path.join(clone_root, "job-456"))
     end
+  end
+
+  defp initialize_git_index(clone_dir, path) do
+    assert {_, 0} = System.cmd("git", ["init", "--quiet", clone_dir], stderr_to_stdout: true)
+
+    assert {_, 0} =
+             System.cmd("git", ["-C", clone_dir, "add", "--", path], stderr_to_stdout: true)
+  end
+
+  defp repo_ref do
+    %RepoRef{
+      owner: "example",
+      name: "platform-api",
+      full_name: "example/platform-api",
+      clone_url: "https://github.com/example/platform-api.git"
+    }
+  end
+
+  defp snapshot_limits do
+    %{
+      "max_repo_files" => 100,
+      "max_selected_files" => 100,
+      "max_file_bytes" => 100_000
+    }
   end
 end


### PR DESCRIPTION
This pull request improves the security and robustness of file handling in the `Valentine.RepoAnalysis.GitHub` module. It ensures that only regular files within the repository are read, preventing accidental or malicious access to files outside the repository through symbolic links. The changes also add comprehensive tests to verify this behavior.

**Security and file validation improvements:**

* Updated `tracked_files/1` to use `git ls-files -z` and split on null characters, improving file name handling and robustness.
* Refactored `read_document/3` to use a new `safe_regular_file/3` helper, which ensures that only regular files within the repository directory are read, and that paths do not escape the repository (e.g., via symlinks or `..`).
* Added `walk_regular_path/2` to safely resolve paths and check directory traversal, further preventing access to files outside the intended directory.

**Testing enhancements:**

* Added tests to ensure that tracked symbolic links to files outside the repository are not read, and that tracked regular files are read as expected.
* Introduced helper functions for test setup, including `initialize_git_index/2`, `repo_ref/0`, and `snapshot_limits/0`, to streamline test cases.