### PR TITLE
fix: idor issues

### DIFF
--- a/valentine/lib/valentine/composer.ex
+++ b/valentine/lib/valentine/composer.ex
@@ -273,6 +273,14 @@ defmodule Valentine.Composer do
     |> Repo.preload(preload)
   end
 
+  def get_threat_model_quality_review_run_for_workspace!(
+        workspace_id,
+        id,
+        preload \\ [:workspace, :findings]
+      ) do
+    get_workspace_entity!(ThreatModelQualityReviewRun, workspace_id, id, preload)
+  end
+
   @doc """
   Gets a single threat model quality review run for an owner.
   """
@@ -471,6 +479,14 @@ defmodule Valentine.Composer do
 
   def get_threat!(id, preload) when is_nil(preload), do: Repo.get!(Threat, id)
 
+  def get_threat_for_workspace!(workspace_id, id, preload \\ nil) do
+    get_workspace_entity!(Threat, workspace_id, id, preload)
+  end
+
+  def get_threat_for_workspace(workspace_id, id, preload \\ nil) do
+    get_workspace_entity(Threat, workspace_id, id, preload)
+  end
+
   @doc """
   Creates a threat.
 
@@ -565,6 +581,14 @@ defmodule Valentine.Composer do
   end
 
   def get_threat_agent!(id, preload) when is_nil(preload), do: Repo.get!(ThreatAgent, id)
+
+  def get_threat_agent_for_workspace!(workspace_id, id, preload \\ nil) do
+    get_workspace_entity!(ThreatAgent, workspace_id, id, preload)
+  end
+
+  def get_threat_agent_for_workspace(workspace_id, id, preload \\ nil) do
+    get_workspace_entity(ThreatAgent, workspace_id, id, preload)
+  end
 
   @doc """
   Creates a threat agent.
@@ -672,6 +696,14 @@ defmodule Valentine.Composer do
   end
 
   def get_assumption!(id, preload) when is_nil(preload), do: Repo.get!(Assumption, id)
+
+  def get_assumption_for_workspace!(workspace_id, id, preload \\ nil) do
+    get_workspace_entity!(Assumption, workspace_id, id, preload)
+  end
+
+  def get_assumption_for_workspace(workspace_id, id, preload \\ nil) do
+    get_workspace_entity(Assumption, workspace_id, id, preload)
+  end
 
   @doc """
   Creates a assumption.
@@ -854,6 +886,14 @@ defmodule Valentine.Composer do
   end
 
   def get_mitigation!(id, preload) when is_nil(preload), do: Repo.get!(Mitigation, id)
+
+  def get_mitigation_for_workspace!(workspace_id, id, preload \\ nil) do
+    get_workspace_entity!(Mitigation, workspace_id, id, preload)
+  end
+
+  def get_mitigation_for_workspace(workspace_id, id, preload \\ nil) do
+    get_workspace_entity(Mitigation, workspace_id, id, preload)
+  end
 
   @doc """
   Creates a mitigation.
@@ -1968,6 +2008,10 @@ defmodule Valentine.Composer do
   """
   def get_api_key(id), do: Repo.get(ApiKey, id)
 
+  def get_api_key_for_workspace(workspace_id, id) do
+    get_workspace_entity(ApiKey, workspace_id, id, nil)
+  end
+
   @doc """
   Creates a api_key.
 
@@ -2104,6 +2148,14 @@ defmodule Valentine.Composer do
   end
 
   def get_evidence!(id, preload) when is_nil(preload), do: Repo.get!(Evidence, id)
+
+  def get_evidence_for_workspace!(workspace_id, id, preload \\ nil) do
+    get_workspace_entity!(Evidence, workspace_id, id, preload)
+  end
+
+  def get_evidence_for_workspace(workspace_id, id, preload \\ nil) do
+    get_workspace_entity(Evidence, workspace_id, id, preload)
+  end
 
   @doc """
   Creates evidence.
@@ -2491,6 +2543,13 @@ defmodule Valentine.Composer do
   """
   def get_brainstorm_item!(id), do: Repo.get!(BrainstormItem, id)
 
+  def get_brainstorm_item!(workspace_id, id) do
+    workspace_id
+    |> brainstorm_items_base_query()
+    |> where([bi], bi.id == ^id)
+    |> Repo.one!()
+  end
+
   @doc """
   Gets a single brainstorm item by id.
 
@@ -2728,6 +2787,30 @@ defmodule Valentine.Composer do
     |> Repo.all()
     |> Enum.into(%{})
   end
+
+  defp get_workspace_entity!(schema, workspace_id, id, preload) do
+    schema
+    |> workspace_entity_query(workspace_id, id)
+    |> Repo.one!()
+    |> preload_workspace_entity(preload)
+  end
+
+  defp get_workspace_entity(schema, workspace_id, id, preload) do
+    schema
+    |> workspace_entity_query(workspace_id, id)
+    |> Repo.one()
+    |> preload_workspace_entity(preload)
+  end
+
+  defp workspace_entity_query(schema, workspace_id, id) do
+    from(entity in schema,
+      where: entity.workspace_id == ^workspace_id and entity.id == ^id
+    )
+  end
+
+  defp preload_workspace_entity(nil, _preload), do: nil
+  defp preload_workspace_entity(entity, nil), do: entity
+  defp preload_workspace_entity(entity, preload), do: Repo.preload(entity, preload)
 
   # Private functions for brainstorm items
 

--- a/valentine/lib/valentine_web/live/workspace_live/api_key/index.ex
+++ b/valentine/lib/valentine_web/live/workspace_live/api_key/index.ex
@@ -35,7 +35,7 @@ defmodule ValentineWeb.WorkspaceLive.ApiKey.Index do
 
   @impl true
   def handle_event("delete", %{"id" => id}, socket) do
-    case Composer.get_api_key(id) do
+    case Composer.get_api_key_for_workspace(socket.assigns.workspace_id, id) do
       nil ->
         {:noreply, socket |> put_flash(:error, gettext("API key not found"))}
 

--- a/valentine/lib/valentine_web/live/workspace_live/assumption/components/form_component.ex
+++ b/valentine/lib/valentine_web/live/workspace_live/assumption/components/form_component.ex
@@ -44,7 +44,6 @@ defmodule ValentineWeb.WorkspaceLive.Assumption.Components.FormComponent do
               }
               is_form_control
             />
-            <input type="hidden" value={@assumption.workspace_id} name="assumption[workspace_id]" />
           </:body>
           <:footer>
             <.button is_primary is_submit phx-disable-with={gettext("Saving...")}>
@@ -70,12 +69,17 @@ defmodule ValentineWeb.WorkspaceLive.Assumption.Components.FormComponent do
 
   @impl true
   def handle_event("validate", %{"assumption" => assumption_params}, socket) do
-    changeset = Composer.change_assumption(socket.assigns.assumption, assumption_params)
+    changeset =
+      Composer.change_assumption(
+        socket.assigns.assumption,
+        trusted_params(socket, assumption_params)
+      )
+
     {:noreply, assign(socket, :changeset, changeset)}
   end
 
   def handle_event("save", %{"assumption" => assumption_params}, socket) do
-    save_assumption(socket, socket.assigns.action, assumption_params)
+    save_assumption(socket, socket.assigns.action, trusted_params(socket, assumption_params))
   end
 
   defp save_assumption(socket, :edit, assumption_params) do
@@ -124,6 +128,20 @@ defmodule ValentineWeb.WorkspaceLive.Assumption.Components.FormComponent do
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, changeset: changeset)}
+    end
+  end
+
+  defp trusted_params(socket, params) do
+    put_trusted_workspace_id(params, socket.assigns.assumption.workspace_id)
+  end
+
+  defp put_trusted_workspace_id(params, workspace_id) do
+    if Enum.all?(Map.keys(params), &is_atom/1) do
+      params |> Map.delete(:workspace_id) |> Map.put(:workspace_id, workspace_id)
+    else
+      params
+      |> Map.new(fn {key, value} -> {to_string(key), value} end)
+      |> Map.put("workspace_id", workspace_id)
     end
   end
 

--- a/valentine/lib/valentine_web/live/workspace_live/assumption/index.ex
+++ b/valentine/lib/valentine_web/live/workspace_live/assumption/index.ex
@@ -30,13 +30,23 @@ defmodule ValentineWeb.WorkspaceLive.Assumption.Index do
   defp apply_action(socket, :edit, %{"id" => id}) do
     socket
     |> assign(:page_title, gettext("Edit Assumption"))
-    |> assign(:assumption, Composer.get_assumption!(id))
+    |> assign(
+      :assumption,
+      Composer.get_assumption_for_workspace!(socket.assigns.workspace_id, id)
+    )
   end
 
   defp apply_action(socket, :categorize, %{"id" => id}) do
     socket
     |> assign(:page_title, gettext("Categorize Assumption"))
-    |> assign(:assumption, Composer.get_assumption!(id, [:mitigations, :threats]))
+    |> assign(
+      :assumption,
+      Composer.get_assumption_for_workspace!(
+        socket.assigns.workspace_id,
+        id,
+        [:mitigations, :threats]
+      )
+    )
   end
 
   defp apply_action(socket, :new, _params) do
@@ -57,14 +67,20 @@ defmodule ValentineWeb.WorkspaceLive.Assumption.Index do
     socket
     |> assign(:page_title, gettext("Link mitigations to assumption"))
     |> assign(:mitigations, socket.assigns.workspace.mitigations)
-    |> assign(:assumption, Composer.get_assumption!(id, [:mitigations]))
+    |> assign(
+      :assumption,
+      Composer.get_assumption_for_workspace!(socket.assigns.workspace_id, id, [:mitigations])
+    )
   end
 
   defp apply_action(socket, :threats, %{"id" => id}) do
     socket
     |> assign(:page_title, gettext("Link threats to assumption"))
     |> assign(:threats, socket.assigns.workspace.threats)
-    |> assign(:assumption, Composer.get_assumption!(id, [:threats]))
+    |> assign(
+      :assumption,
+      Composer.get_assumption_for_workspace!(socket.assigns.workspace_id, id, [:threats])
+    )
   end
 
   @impl true
@@ -103,7 +119,7 @@ defmodule ValentineWeb.WorkspaceLive.Assumption.Index do
 
   @impl true
   def handle_event("delete", %{"id" => id}, socket) do
-    case Composer.get_assumption!(id) do
+    case Composer.get_assumption_for_workspace(socket.assigns.workspace_id, id) do
       nil ->
         {:noreply, socket |> put_flash(:error, gettext("Assumption not found"))}
 

--- a/valentine/lib/valentine_web/live/workspace_live/brainstorm/components/threat_builder_component.ex
+++ b/valentine/lib/valentine_web/live/workspace_live/brainstorm/components/threat_builder_component.ex
@@ -502,7 +502,7 @@ defmodule ValentineWeb.WorkspaceLive.Brainstorm.Components.ThreatBuilderComponen
 
     case Composer.create_threat(threat_attrs) do
       {:ok, threat} ->
-        update_card_usage(selected_card_ids, threat.numeric_id)
+        update_card_usage(socket.assigns.workspace_id, selected_card_ids, threat.numeric_id)
         {:ok, [threat]}
 
       {:error, changeset} ->
@@ -510,9 +510,9 @@ defmodule ValentineWeb.WorkspaceLive.Brainstorm.Components.ThreatBuilderComponen
     end
   end
 
-  defp update_card_usage(card_ids, threat_numeric_id) do
+  defp update_card_usage(workspace_id, card_ids, threat_numeric_id) do
     Enum.each(card_ids, fn card_id ->
-      case Composer.get_brainstorm_item(card_id) do
+      case Composer.get_brainstorm_item(workspace_id, card_id) do
         nil ->
           :skip
 

--- a/valentine/lib/valentine_web/live/workspace_live/brainstorm/index.ex
+++ b/valentine/lib/valentine_web/live/workspace_live/brainstorm/index.ex
@@ -105,7 +105,7 @@ defmodule ValentineWeb.WorkspaceLive.Brainstorm.Index do
   # Update existing brainstorm item
   @impl true
   def handle_event("update_item", %{"item_id" => id, "text" => text, "type" => type}, socket) do
-    item = Composer.get_brainstorm_item!(id)
+    item = Composer.get_brainstorm_item!(socket.assigns.workspace_id, id)
 
     update_attrs = %{raw_text: text}
 
@@ -134,7 +134,7 @@ defmodule ValentineWeb.WorkspaceLive.Brainstorm.Index do
   end
 
   def handle_event("update_item", %{"item_id" => id, "text" => text}, socket) do
-    item = Composer.get_brainstorm_item!(id)
+    item = Composer.get_brainstorm_item!(socket.assigns.workspace_id, id)
 
     case Composer.update_brainstorm_item(item, %{raw_text: text}) do
       {:ok, updated_item} ->
@@ -156,7 +156,7 @@ defmodule ValentineWeb.WorkspaceLive.Brainstorm.Index do
   # Delete brainstorm item with undo capability
   @impl true
   def handle_event("delete_item", %{"id" => id}, socket) do
-    item = Composer.get_brainstorm_item!(id)
+    item = Composer.get_brainstorm_item!(socket.assigns.workspace_id, id)
 
     case Composer.delete_brainstorm_item(item) do
       {:ok, deleted_item} ->
@@ -221,7 +221,7 @@ defmodule ValentineWeb.WorkspaceLive.Brainstorm.Index do
   # Update item status
   @impl true
   def handle_event("update_status", %{"id" => id, "status" => status}, socket) do
-    item = Composer.get_brainstorm_item!(id)
+    item = Composer.get_brainstorm_item!(socket.assigns.workspace_id, id)
 
     case Composer.update_brainstorm_item(item, %{status: String.to_existing_atom(status)}) do
       {:ok, updated_item} ->
@@ -242,7 +242,7 @@ defmodule ValentineWeb.WorkspaceLive.Brainstorm.Index do
   # Drag & drop move between categories (types)
   @impl true
   def handle_event("move_item", %{"id" => id, "type" => new_type}, socket) do
-    item = Composer.get_brainstorm_item!(id)
+    item = Composer.get_brainstorm_item!(socket.assigns.workspace_id, id)
 
     cond do
       new_type == Atom.to_string(item.type) ->
@@ -296,7 +296,7 @@ defmodule ValentineWeb.WorkspaceLive.Brainstorm.Index do
   # Assign item to cluster
   @impl true
   def handle_event("start_cluster_assign", %{"id" => id}, socket) do
-    item = Composer.get_brainstorm_item!(id)
+    item = Composer.get_brainstorm_item!(socket.assigns.workspace_id, id)
     clusters = Composer.list_clusters_by_type(socket.assigns.workspace_id, item.type)
 
     {:noreply,
@@ -319,7 +319,7 @@ defmodule ValentineWeb.WorkspaceLive.Brainstorm.Index do
 
   @impl true
   def handle_event("assign_cluster", params = %{"id" => id}, socket) do
-    item = Composer.get_brainstorm_item!(id)
+    item = Composer.get_brainstorm_item!(socket.assigns.workspace_id, id)
 
     cluster_key =
       cond do

--- a/valentine/lib/valentine_web/live/workspace_live/evidence/index.ex
+++ b/valentine/lib/valentine_web/live/workspace_live/evidence/index.ex
@@ -34,7 +34,12 @@ defmodule ValentineWeb.WorkspaceLive.Evidence.Index do
   end
 
   defp apply_action(socket, :assumptions, %{"id" => evidence_id}) do
-    evidence_item = Composer.get_evidence!(evidence_id, [:assumptions])
+    evidence_item =
+      Composer.get_evidence_for_workspace!(
+        socket.assigns.workspace_id,
+        evidence_id,
+        [:assumptions]
+      )
 
     socket
     |> assign(:page_title, gettext("Link Evidence"))
@@ -46,7 +51,8 @@ defmodule ValentineWeb.WorkspaceLive.Evidence.Index do
   end
 
   defp apply_action(socket, :threats, %{"id" => evidence_id}) do
-    evidence_item = Composer.get_evidence!(evidence_id, [:threats])
+    evidence_item =
+      Composer.get_evidence_for_workspace!(socket.assigns.workspace_id, evidence_id, [:threats])
 
     socket
     |> assign(:page_title, gettext("Link Evidence"))
@@ -58,7 +64,12 @@ defmodule ValentineWeb.WorkspaceLive.Evidence.Index do
   end
 
   defp apply_action(socket, :mitigations, %{"id" => evidence_id}) do
-    evidence_item = Composer.get_evidence!(evidence_id, [:mitigations])
+    evidence_item =
+      Composer.get_evidence_for_workspace!(
+        socket.assigns.workspace_id,
+        evidence_id,
+        [:mitigations]
+      )
 
     socket
     |> assign(:page_title, gettext("Link Evidence"))
@@ -71,7 +82,7 @@ defmodule ValentineWeb.WorkspaceLive.Evidence.Index do
 
   @impl true
   def handle_event("delete", %{"id" => id}, socket) do
-    case Composer.get_evidence!(id) do
+    case Composer.get_evidence_for_workspace(socket.assigns.workspace_id, id) do
       nil ->
         {:noreply, socket |> put_flash(:error, gettext("Evidence not found"))}
 

--- a/valentine/lib/valentine_web/live/workspace_live/evidence/show.ex
+++ b/valentine/lib/valentine_web/live/workspace_live/evidence/show.ex
@@ -40,19 +40,13 @@ defmodule ValentineWeb.WorkspaceLive.Evidence.Show do
   end
 
   defp apply_action(socket, :edit, %{"id" => id} = _params) do
-    evidence = Composer.get_evidence!(id)
+    evidence = Composer.get_evidence_for_workspace!(socket.assigns.workspace_id, id)
 
-    if evidence.workspace_id != socket.assigns.workspace_id do
-      socket
-      |> put_flash(:error, gettext("Not found"))
-      |> push_navigate(to: ~p"/workspaces/#{socket.assigns.workspace_id}/evidence")
-    else
-      socket
-      |> assign(:page_title, gettext("Edit Evidence"))
-      |> assign(:evidence, evidence)
-      |> assign(:changes, Map.from_struct(evidence))
-      |> assign(:content_raw, encode_content(evidence.content))
-    end
+    socket
+    |> assign(:page_title, gettext("Edit Evidence"))
+    |> assign(:evidence, evidence)
+    |> assign(:changes, Map.from_struct(evidence))
+    |> assign(:content_raw, encode_content(evidence.content))
   end
 
   @impl true

--- a/valentine/lib/valentine_web/live/workspace_live/mitigation/components/form_component.ex
+++ b/valentine/lib/valentine_web/live/workspace_live/mitigation/components/form_component.ex
@@ -44,7 +44,6 @@ defmodule ValentineWeb.WorkspaceLive.Mitigation.Components.FormComponent do
               }
               is_form_control
             />
-            <input type="hidden" value={@mitigation.workspace_id} name="mitigation[workspace_id]" />
           </:body>
           <:footer>
             <.button is_primary is_submit phx-disable-with={gettext("Saving...")}>
@@ -70,12 +69,17 @@ defmodule ValentineWeb.WorkspaceLive.Mitigation.Components.FormComponent do
 
   @impl true
   def handle_event("validate", %{"mitigation" => mitigation_params}, socket) do
-    changeset = Composer.change_mitigation(socket.assigns.mitigation, mitigation_params)
+    changeset =
+      Composer.change_mitigation(
+        socket.assigns.mitigation,
+        trusted_params(socket, mitigation_params)
+      )
+
     {:noreply, assign(socket, :changeset, changeset)}
   end
 
   def handle_event("save", %{"mitigation" => mitigation_params}, socket) do
-    save_mitigation(socket, socket.assigns.action, mitigation_params)
+    save_mitigation(socket, socket.assigns.action, trusted_params(socket, mitigation_params))
   end
 
   defp save_mitigation(socket, :edit, mitigation_params) do
@@ -121,6 +125,20 @@ defmodule ValentineWeb.WorkspaceLive.Mitigation.Components.FormComponent do
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, changeset: changeset)}
+    end
+  end
+
+  defp trusted_params(socket, params) do
+    put_trusted_workspace_id(params, socket.assigns.mitigation.workspace_id)
+  end
+
+  defp put_trusted_workspace_id(params, workspace_id) do
+    if Enum.all?(Map.keys(params), &is_atom/1) do
+      params |> Map.delete(:workspace_id) |> Map.put(:workspace_id, workspace_id)
+    else
+      params
+      |> Map.new(fn {key, value} -> {to_string(key), value} end)
+      |> Map.put("workspace_id", workspace_id)
     end
   end
 

--- a/valentine/lib/valentine_web/live/workspace_live/mitigation/index.ex
+++ b/valentine/lib/valentine_web/live/workspace_live/mitigation/index.ex
@@ -30,26 +30,38 @@ defmodule ValentineWeb.WorkspaceLive.Mitigation.Index do
     socket
     |> assign(:page_title, gettext("Link assumptions to mitigation"))
     |> assign(:assumptions, socket.assigns.workspace.assumptions)
-    |> assign(:mitigation, Composer.get_mitigation!(id, [:assumptions]))
+    |> assign(
+      :mitigation,
+      Composer.get_mitigation_for_workspace!(socket.assigns.workspace_id, id, [:assumptions])
+    )
   end
 
   defp apply_action(socket, :categorize, %{"id" => id}) do
     socket
     |> assign(:page_title, gettext("Categorize Mitigation"))
-    |> assign(:mitigation, Composer.get_mitigation!(id, [:threats]))
+    |> assign(
+      :mitigation,
+      Composer.get_mitigation_for_workspace!(socket.assigns.workspace_id, id, [:threats])
+    )
   end
 
   defp apply_action(socket, :edit, %{"id" => id}) do
     socket
     |> assign(:page_title, gettext("Edit Mitigation"))
-    |> assign(:mitigation, Composer.get_mitigation!(id))
+    |> assign(
+      :mitigation,
+      Composer.get_mitigation_for_workspace!(socket.assigns.workspace_id, id)
+    )
   end
 
   defp apply_action(socket, :threats, %{"id" => id}) do
     socket
     |> assign(:page_title, gettext("Link threats to mitigation"))
     |> assign(:threats, socket.assigns.workspace.threats)
-    |> assign(:mitigation, Composer.get_mitigation!(id, [:threats]))
+    |> assign(
+      :mitigation,
+      Composer.get_mitigation_for_workspace!(socket.assigns.workspace_id, id, [:threats])
+    )
   end
 
   defp apply_action(socket, :new, _params) do
@@ -68,7 +80,7 @@ defmodule ValentineWeb.WorkspaceLive.Mitigation.Index do
 
   @impl true
   def handle_event("delete", %{"id" => id}, socket) do
-    case Composer.get_mitigation!(id) do
+    case Composer.get_mitigation_for_workspace(socket.assigns.workspace_id, id) do
       nil ->
         {:noreply, socket |> put_flash(:error, gettext("Mitigation not found"))}
 

--- a/valentine/lib/valentine_web/live/workspace_live/threat/index.ex
+++ b/valentine/lib/valentine_web/live/workspace_live/threat/index.ex
@@ -26,18 +26,13 @@ defmodule ValentineWeb.WorkspaceLive.Threat.Index do
   end
 
   defp apply_action(socket, :assumptions, %{"id" => id}) do
-    threat = Composer.get_threat!(id, [:assumptions])
+    threat =
+      Composer.get_threat_for_workspace!(socket.assigns.workspace_id, id, [:assumptions])
 
-    if threat.workspace_id != socket.assigns.workspace_id do
-      socket
-      |> put_flash(:error, gettext("Not found"))
-      |> push_navigate(to: ~p"/workspaces/#{socket.assigns.workspace_id}/threats")
-    else
-      socket
-      |> assign(:page_title, gettext("Link assumptions to threat"))
-      |> assign(:assumptions, socket.assigns.workspace.assumptions)
-      |> assign(:threat, threat)
-    end
+    socket
+    |> assign(:page_title, gettext("Link assumptions to threat"))
+    |> assign(:assumptions, socket.assigns.workspace.assumptions)
+    |> assign(:threat, threat)
   end
 
   defp apply_action(socket, :index, %{"workspace_id" => workspace_id} = _params) do
@@ -47,23 +42,18 @@ defmodule ValentineWeb.WorkspaceLive.Threat.Index do
   end
 
   defp apply_action(socket, :mitigations, %{"id" => id}) do
-    threat = Composer.get_threat!(id, [:mitigations])
+    threat =
+      Composer.get_threat_for_workspace!(socket.assigns.workspace_id, id, [:mitigations])
 
-    if threat.workspace_id != socket.assigns.workspace_id do
-      socket
-      |> put_flash(:error, gettext("Not found"))
-      |> push_navigate(to: ~p"/workspaces/#{socket.assigns.workspace_id}/threats")
-    else
-      socket
-      |> assign(:page_title, gettext("Link mitigations to threat"))
-      |> assign(:mitigations, socket.assigns.workspace.mitigations)
-      |> assign(:threat, threat)
-    end
+    socket
+    |> assign(:page_title, gettext("Link mitigations to threat"))
+    |> assign(:mitigations, socket.assigns.workspace.mitigations)
+    |> assign(:threat, threat)
   end
 
   @impl true
   def handle_event("delete", %{"id" => id}, socket) do
-    case Composer.get_threat!(id) do
+    case Composer.get_threat_for_workspace(socket.assigns.workspace_id, id) do
       nil ->
         {:noreply, socket |> put_flash(:error, gettext("Threat not found"))}
 

--- a/valentine/lib/valentine_web/live/workspace_live/threat/show.ex
+++ b/valentine/lib/valentine_web/live/workspace_live/threat/show.ex
@@ -7,7 +7,6 @@ defmodule ValentineWeb.WorkspaceLive.Threat.Show do
   alias Valentine.Composer.DeliberateThreatLevel
   alias Valentine.Composer.Mitigation
   alias Valentine.Composer.Threat
-  alias Valentine.Repo
 
   @impl true
   def mount(%{"workspace_id" => workspace_id} = _params, _session, socket) do
@@ -40,8 +39,11 @@ defmodule ValentineWeb.WorkspaceLive.Threat.Show do
     workspace = get_workspace(socket.assigns.workspace_id)
 
     threat =
-      Composer.get_threat!(id)
-      |> Repo.preload([:assumptions, :mitigations])
+      Composer.get_threat_for_workspace!(
+        socket.assigns.workspace_id,
+        id,
+        [:assumptions, :mitigations]
+      )
 
     socket
     |> assign(:assumptions, workspace.assumptions)
@@ -125,7 +127,7 @@ defmodule ValentineWeb.WorkspaceLive.Threat.Show do
   @impl true
   def handle_event("remove_assumption", %{"id" => id}, socket) do
     threat = socket.assigns.threat
-    assumption = Composer.get_assumption!(id)
+    assumption = Composer.get_assumption_for_workspace!(workspace_id(socket), id)
 
     {:ok, threat} = Composer.remove_assumption_from_threat(threat, assumption)
 
@@ -135,7 +137,7 @@ defmodule ValentineWeb.WorkspaceLive.Threat.Show do
   @impl true
   def handle_event("remove_mitigation", %{"id" => id}, socket) do
     threat = socket.assigns.threat
-    mitigation = Composer.get_mitigation!(id)
+    mitigation = Composer.get_mitigation_for_workspace!(workspace_id(socket), id)
 
     {:ok, threat} = Composer.remove_mitigation_from_threat(threat, mitigation)
 
@@ -169,7 +171,12 @@ defmodule ValentineWeb.WorkspaceLive.Threat.Show do
 
   def handle_info({"assumptions", :selected_item, selected_item}, socket) do
     threat = socket.assigns.threat
-    assumption = Composer.get_assumption!(selected_item.id)
+
+    assumption =
+      Composer.get_assumption_for_workspace!(
+        workspace_id(socket),
+        selected_item.id
+      )
 
     {:ok, threat} = Composer.add_assumption_to_threat(threat, assumption)
 
@@ -178,7 +185,12 @@ defmodule ValentineWeb.WorkspaceLive.Threat.Show do
 
   def handle_info({"mitigations", :selected_item, selected_item}, socket) do
     threat = socket.assigns.threat
-    mitigation = Composer.get_mitigation!(selected_item.id)
+
+    mitigation =
+      Composer.get_mitigation_for_workspace!(
+        workspace_id(socket),
+        selected_item.id
+      )
 
     {:ok, threat} = Composer.add_mitigation_to_threat(threat, mitigation)
 
@@ -186,7 +198,7 @@ defmodule ValentineWeb.WorkspaceLive.Threat.Show do
   end
 
   defp update_existing_threat(socket) do
-    case Composer.update_threat(socket.assigns.threat, socket.assigns.changes) do
+    case Composer.update_threat(socket.assigns.threat, trusted_threat_changes(socket)) do
       {:ok, threat} ->
         broadcast_threat_change(threat, "threat_updated")
 
@@ -209,7 +221,7 @@ defmodule ValentineWeb.WorkspaceLive.Threat.Show do
   end
 
   defp create_new_threat(socket) do
-    case Composer.create_threat(socket.assigns.changes) do
+    case Composer.create_threat(trusted_threat_changes(socket)) do
       {:ok, threat} ->
         broadcast_threat_change(threat, "threat_created")
 
@@ -276,6 +288,15 @@ defmodule ValentineWeb.WorkspaceLive.Threat.Show do
 
   def classification_display(field, value) do
     Threat.classification_label(field, value) || gettext("Not set")
+  end
+
+  defp workspace_id(socket) do
+    socket.assigns[:workspace_id] ||
+      (socket.assigns[:threat] && socket.assigns.threat.workspace_id)
+  end
+
+  defp trusted_threat_changes(socket) do
+    Map.put(socket.assigns.changes || %{}, :workspace_id, workspace_id(socket))
   end
 
   defp broadcast_threat_change(threat, event) do

--- a/valentine/lib/valentine_web/live/workspace_live/threat_agent/components/form_component.ex
+++ b/valentine/lib/valentine_web/live/workspace_live/threat_agent/components/form_component.ex
@@ -69,8 +69,6 @@ defmodule ValentineWeb.WorkspaceLive.ThreatAgent.Components.FormComponent do
               form_control={%{label: gettext("Deliberate Threat Level")}}
               is_form_control
             />
-
-            <input type="hidden" value={@threat_agent.workspace_id} name="threat_agent[workspace_id]" />
           </:body>
           <:footer>
             <.button is_primary is_submit phx-disable-with={gettext("Saving...")}>
@@ -96,12 +94,17 @@ defmodule ValentineWeb.WorkspaceLive.ThreatAgent.Components.FormComponent do
 
   @impl true
   def handle_event("validate", %{"threat_agent" => threat_agent_params}, socket) do
-    changeset = Composer.change_threat_agent(socket.assigns.threat_agent, threat_agent_params)
+    changeset =
+      Composer.change_threat_agent(
+        socket.assigns.threat_agent,
+        trusted_params(socket, threat_agent_params)
+      )
+
     {:noreply, assign(socket, :changeset, changeset)}
   end
 
   def handle_event("save", %{"threat_agent" => threat_agent_params}, socket) do
-    save_threat_agent(socket, socket.assigns.action, threat_agent_params)
+    save_threat_agent(socket, socket.assigns.action, trusted_params(socket, threat_agent_params))
   end
 
   defp save_threat_agent(socket, :edit, threat_agent_params) do
@@ -136,6 +139,20 @@ defmodule ValentineWeb.WorkspaceLive.ThreatAgent.Components.FormComponent do
 
   defp td_level_options do
     Enum.map(DeliberateThreatLevel.options(), fn {label, value} -> [key: label, value: value] end)
+  end
+
+  defp trusted_params(socket, params) do
+    put_trusted_workspace_id(params, socket.assigns.threat_agent.workspace_id)
+  end
+
+  defp put_trusted_workspace_id(params, workspace_id) do
+    if Enum.all?(Map.keys(params), &is_atom/1) do
+      params |> Map.delete(:workspace_id) |> Map.put(:workspace_id, workspace_id)
+    else
+      params
+      |> Map.new(fn {key, value} -> {to_string(key), value} end)
+      |> Map.put("workspace_id", workspace_id)
+    end
   end
 
   defp notify_parent(msg), do: send(self(), {__MODULE__, msg})

--- a/valentine/lib/valentine_web/live/workspace_live/threat_agent/index.ex
+++ b/valentine/lib/valentine_web/live/workspace_live/threat_agent/index.ex
@@ -26,7 +26,10 @@ defmodule ValentineWeb.WorkspaceLive.ThreatAgent.Index do
   defp apply_action(socket, :edit, %{"id" => id}) do
     socket
     |> assign(:page_title, gettext("Edit Threat Agent"))
-    |> assign(:threat_agent, Composer.get_threat_agent!(id))
+    |> assign(
+      :threat_agent,
+      Composer.get_threat_agent_for_workspace!(socket.assigns.workspace_id, id)
+    )
   end
 
   defp apply_action(socket, :new, _params) do
@@ -52,9 +55,15 @@ defmodule ValentineWeb.WorkspaceLive.ThreatAgent.Index do
   def handle_info({:selected_label_dropdown, id, "td_level", value}, socket) do
     threat_agent_id = String.replace_prefix(id, "threat-agent-td-level-", "")
 
-    case Composer.update_threat_agent(Composer.get_threat_agent!(threat_agent_id), %{
-           "td_level" => value
-         }) do
+    case Composer.update_threat_agent(
+           Composer.get_threat_agent_for_workspace!(
+             socket.assigns.workspace_id,
+             threat_agent_id
+           ),
+           %{
+             "td_level" => value
+           }
+         ) do
       {:ok, _threat_agent} ->
         {:noreply,
          assign(socket, :threat_agents, Composer.list_threat_agents(socket.assigns.workspace_id))}
@@ -72,7 +81,7 @@ defmodule ValentineWeb.WorkspaceLive.ThreatAgent.Index do
   @impl true
   def handle_event("delete", %{"id" => id}, socket) do
     try do
-      threat_agent = Composer.get_threat_agent!(id)
+      threat_agent = Composer.get_threat_agent_for_workspace(socket.assigns.workspace_id, id)
 
       case threat_agent do
         nil ->

--- a/valentine/lib/valentine_web/live/workspace_live/threat_model/review_show.ex
+++ b/valentine/lib/valentine_web/live/workspace_live/threat_model/review_show.ex
@@ -26,11 +26,12 @@ defmodule ValentineWeb.WorkspaceLive.ThreatModel.ReviewShow do
   end
 
   defp assign_review(socket, workspace_id, id) do
-    review_run = Composer.get_threat_model_quality_review_run!(id, [:findings, :workspace])
-
-    if review_run.workspace_id != workspace_id do
-      raise Ecto.NoResultsError, queryable: Valentine.Composer.ThreatModelQualityReviewRun
-    end
+    review_run =
+      Composer.get_threat_model_quality_review_run_for_workspace!(
+        workspace_id,
+        id,
+        [:findings, :workspace]
+      )
 
     findings = Composer.list_threat_model_quality_review_findings_by_run(id)
 

--- a/valentine/test/valentine/composer_test.exs
+++ b/valentine/test/valentine/composer_test.exs
@@ -1795,4 +1795,66 @@ defmodule Valentine.ComposerTest do
       assert %Ecto.Association.NotLoaded{} = loaded_evidence.assumptions
     end
   end
+
+  describe "workspace-scoped entity lookups" do
+    import Valentine.ComposerFixtures
+
+    test "do not return records belonging to another workspace" do
+      workspace = workspace_fixture()
+      other_workspace = workspace_fixture(%{owner: "other.owner@localhost"})
+
+      threat = threat_fixture(%{workspace_id: other_workspace.id})
+      assumption = assumption_fixture(%{workspace_id: other_workspace.id})
+      mitigation = mitigation_fixture(%{workspace_id: other_workspace.id})
+      evidence = evidence_fixture(%{workspace_id: other_workspace.id})
+      threat_agent = threat_agent_fixture(%{workspace_id: other_workspace.id})
+      api_key = api_key_fixture(%{workspace_id: other_workspace.id})
+      brainstorm_item = brainstorm_item_fixture(%{workspace_id: other_workspace.id})
+
+      review_run =
+        threat_model_quality_review_run_fixture(%{
+          workspace_id: other_workspace.id,
+          owner: other_workspace.owner
+        })
+
+      assert Composer.get_threat_for_workspace(workspace.id, threat.id) == nil
+      assert Composer.get_assumption_for_workspace(workspace.id, assumption.id) == nil
+      assert Composer.get_mitigation_for_workspace(workspace.id, mitigation.id) == nil
+      assert Composer.get_evidence_for_workspace(workspace.id, evidence.id) == nil
+      assert Composer.get_threat_agent_for_workspace(workspace.id, threat_agent.id) == nil
+      assert Composer.get_api_key_for_workspace(workspace.id, api_key.id) == nil
+      assert Composer.get_brainstorm_item(workspace.id, brainstorm_item.id) == nil
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Composer.get_threat_for_workspace!(workspace.id, threat.id)
+      end
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Composer.get_assumption_for_workspace!(workspace.id, assumption.id)
+      end
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Composer.get_mitigation_for_workspace!(workspace.id, mitigation.id)
+      end
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Composer.get_evidence_for_workspace!(workspace.id, evidence.id)
+      end
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Composer.get_threat_agent_for_workspace!(workspace.id, threat_agent.id)
+      end
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Composer.get_brainstorm_item!(workspace.id, brainstorm_item.id)
+      end
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Composer.get_threat_model_quality_review_run_for_workspace!(
+          workspace.id,
+          review_run.id
+        )
+      end
+    end
+  end
 end

--- a/valentine/test/valentine_web/live/workspace/api_key/index_test.exs
+++ b/valentine/test/valentine_web/live/workspace/api_key/index_test.exs
@@ -87,7 +87,7 @@ defmodule ValentineWeb.WorkspaceLive.ApiKey.IndexTest do
 
     test "handles not found api_key", %{socket: socket, api_key: api_key} do
       with_mock Composer,
-        get_api_key: fn _id -> nil end do
+        get_api_key_for_workspace: fn _workspace_id, _id -> nil end do
         {:noreply, updated_socket} =
           ValentineWeb.WorkspaceLive.ApiKey.Index.handle_event(
             "delete",
@@ -101,7 +101,7 @@ defmodule ValentineWeb.WorkspaceLive.ApiKey.IndexTest do
 
     test "handles delete error", %{socket: socket, api_key: api_key} do
       with_mock Composer,
-        get_api_key: fn _api_key_id -> api_key end,
+        get_api_key_for_workspace: fn _workspace_id, _id -> api_key end,
         delete_api_key: fn _api_key -> {:error, "some error"} end do
         {:noreply, updated_socket} =
           ValentineWeb.WorkspaceLive.ApiKey.Index.handle_event(

--- a/valentine/test/valentine_web/live/workspace/assumption/index_test.exs
+++ b/valentine/test/valentine_web/live/workspace/assumption/index_test.exs
@@ -124,7 +124,7 @@ defmodule ValentineWeb.WorkspaceLive.Assumption.IndexTest do
 
   test "handles not found assumption", %{socket: socket, assumption: assumption} do
     with_mock Composer,
-      get_assumption!: fn _id -> nil end do
+      get_assumption_for_workspace: fn _workspace_id, _id -> nil end do
       {:noreply, updated_socket} =
         ValentineWeb.WorkspaceLive.Assumption.Index.handle_event(
           "delete",
@@ -138,7 +138,7 @@ defmodule ValentineWeb.WorkspaceLive.Assumption.IndexTest do
 
   test "handles delete error", %{socket: socket, assumption: assumption} do
     with_mock Composer,
-      get_assumption!: fn _assumption_id -> assumption end,
+      get_assumption_for_workspace: fn _workspace_id, _id -> assumption end,
       delete_assumption: fn _assumption -> {:error, "some error"} end do
       {:noreply, updated_socket} =
         ValentineWeb.WorkspaceLive.Assumption.Index.handle_event(

--- a/valentine/test/valentine_web/live/workspace/assumption/index_view_test.exs
+++ b/valentine/test/valentine_web/live/workspace/assumption/index_view_test.exs
@@ -4,7 +4,7 @@ defmodule ValentineWeb.WorkspaceLive.Assumption.IndexViewTest do
   import Phoenix.LiveViewTest
   import Valentine.ComposerFixtures
 
-  @create_attrs %{content: "some content", workspace_id: nil}
+  @create_attrs %{content: "some content"}
   @update_attrs %{content: "some updated content"}
 
   defp create_assumption(_) do
@@ -40,7 +40,7 @@ defmodule ValentineWeb.WorkspaceLive.Assumption.IndexViewTest do
 
       assert index_live
              |> form("#assumptions-form",
-               assumption: %{@create_attrs | workspace_id: workspace_id}
+               assumption: @create_attrs
              )
              |> render_submit()
 

--- a/valentine/test/valentine_web/live/workspace/mitigation/components/form_component_test.exs
+++ b/valentine/test/valentine_web/live/workspace/mitigation/components/form_component_test.exs
@@ -123,7 +123,7 @@ defmodule ValentineWeb.WorkspaceLive.Mitigation.Components.FormComponentTest do
           __changed__: %{},
           action: :new,
           mitigation: %Valentine.Composer.Mitigation{
-            workspace_id: "00000000-0000-0000-0000-000000000000"
+            workspace_id: assigns.mitigation.workspace_id
           },
           current_user: assigns.current_user,
           flash: %{},
@@ -136,8 +136,7 @@ defmodule ValentineWeb.WorkspaceLive.Mitigation.Components.FormComponentTest do
           "save",
           %{
             "mitigation" => %{
-              content: "some content",
-              workspace_id: assigns.mitigation.workspace_id
+              content: "some content"
             }
           },
           socket

--- a/valentine/test/valentine_web/live/workspace/mitigation/index_test.exs
+++ b/valentine/test/valentine_web/live/workspace/mitigation/index_test.exs
@@ -164,7 +164,7 @@ defmodule ValentineWeb.WorkspaceLive.Mitigation.IndexTest do
 
     test "handles not found mitigation", %{socket: socket, mitigation: mitigation} do
       with_mock Composer,
-        get_mitigation!: fn _id -> nil end do
+        get_mitigation_for_workspace: fn _workspace_id, _id -> nil end do
         {:noreply, updated_socket} =
           ValentineWeb.WorkspaceLive.Mitigation.Index.handle_event(
             "delete",
@@ -178,7 +178,7 @@ defmodule ValentineWeb.WorkspaceLive.Mitigation.IndexTest do
 
     test "handles delete error", %{socket: socket, mitigation: mitigation} do
       with_mock Composer,
-        get_mitigation!: fn _mitigation_id -> mitigation end,
+        get_mitigation_for_workspace: fn _workspace_id, _id -> mitigation end,
         delete_mitigation: fn _mitigation -> {:error, "some error"} end do
         {:noreply, updated_socket} =
           ValentineWeb.WorkspaceLive.Mitigation.Index.handle_event(

--- a/valentine/test/valentine_web/live/workspace/mitigation/index_view_test.exs
+++ b/valentine/test/valentine_web/live/workspace/mitigation/index_view_test.exs
@@ -4,7 +4,7 @@ defmodule ValentineWeb.WorkspaceLive.Mitigation.IndexViewTest do
   import Phoenix.LiveViewTest
   import Valentine.ComposerFixtures
 
-  @create_attrs %{content: "some content", workspace_id: nil}
+  @create_attrs %{content: "some content"}
   @update_attrs %{content: "some updated content"}
 
   defp create_mitigation(_) do
@@ -40,7 +40,7 @@ defmodule ValentineWeb.WorkspaceLive.Mitigation.IndexViewTest do
 
       assert index_live
              |> form("#mitigations-form",
-               mitigation: %{@create_attrs | workspace_id: workspace_id}
+               mitigation: @create_attrs
              )
              |> render_submit()
 

--- a/valentine/test/valentine_web/live/workspace/threat/index_test.exs
+++ b/valentine/test/valentine_web/live/workspace/threat/index_test.exs
@@ -71,7 +71,7 @@ defmodule ValentineWeb.WorkspaceLive.Threat.IndexTest do
 
     test "handles not found threat", %{socket: socket} do
       with_mock Composer,
-        get_threat!: fn _id -> nil end do
+        get_threat_for_workspace: fn _workspace_id, _id -> nil end do
         {:noreply, updated_socket} =
           ValentineWeb.WorkspaceLive.Threat.Index.handle_event(
             "delete",
@@ -85,7 +85,7 @@ defmodule ValentineWeb.WorkspaceLive.Threat.IndexTest do
 
     test "handles delete error", %{socket: socket, threat: threat} do
       with_mock Composer,
-        get_threat!: fn _id -> threat end,
+        get_threat_for_workspace: fn _workspace_id, _id -> threat end,
         delete_threat: fn _threat -> {:error, "some error"} end do
         {:noreply, updated_socket} =
           ValentineWeb.WorkspaceLive.Threat.Index.handle_event(

--- a/valentine/test/valentine_web/live/workspace/threat/show_test.exs
+++ b/valentine/test/valentine_web/live/workspace/threat/show_test.exs
@@ -276,7 +276,7 @@ defmodule ValentineWeb.WorkspaceLive.Threat.ShowTest do
 
   describe "handle_event removes an assumption" do
     test "removes an assumption", %{socket: socket, threat: threat} do
-      assumption = assumption_fixture()
+      assumption = assumption_fixture(%{workspace_id: threat.workspace_id})
 
       Composer.add_assumption_to_threat(threat, assumption)
 
@@ -295,7 +295,7 @@ defmodule ValentineWeb.WorkspaceLive.Threat.ShowTest do
 
   describe "handle_event removes a mitigation" do
     test "removes a mitigation", %{socket: socket, threat: threat} do
-      mitigation = mitigation_fixture()
+      mitigation = mitigation_fixture(%{workspace_id: threat.workspace_id})
 
       Composer.add_mitigation_to_threat(threat, mitigation)
 
@@ -331,7 +331,7 @@ defmodule ValentineWeb.WorkspaceLive.Threat.ShowTest do
     test "adds a newly created assumption to a threat", %{socket: socket, threat: threat} do
       socket = put_in(socket.assigns.threat, threat)
 
-      assumption = assumption_fixture()
+      assumption = assumption_fixture(%{workspace_id: threat.workspace_id})
 
       {:noreply, updated_socket} =
         ValentineWeb.WorkspaceLive.Threat.Show.handle_info(
@@ -347,7 +347,7 @@ defmodule ValentineWeb.WorkspaceLive.Threat.ShowTest do
     test "adds a newly created mitigation to a threat", %{socket: socket, threat: threat} do
       socket = put_in(socket.assigns.threat, threat)
 
-      mitigation = mitigation_fixture()
+      mitigation = mitigation_fixture(%{workspace_id: threat.workspace_id})
 
       {:noreply, updated_socket} =
         ValentineWeb.WorkspaceLive.Threat.Show.handle_info(
@@ -363,7 +363,7 @@ defmodule ValentineWeb.WorkspaceLive.Threat.ShowTest do
     test "adds an assumption to a threat", %{socket: socket, threat: threat} do
       socket = put_in(socket.assigns.threat, threat)
 
-      assumption = assumption_fixture()
+      assumption = assumption_fixture(%{workspace_id: threat.workspace_id})
 
       {:noreply, updated_socket} =
         ValentineWeb.WorkspaceLive.Threat.Show.handle_info(
@@ -379,7 +379,7 @@ defmodule ValentineWeb.WorkspaceLive.Threat.ShowTest do
     test "adds an mitigation to a threat", %{socket: socket, threat: threat} do
       socket = put_in(socket.assigns.threat, threat)
 
-      mitigation = mitigation_fixture()
+      mitigation = mitigation_fixture(%{workspace_id: threat.workspace_id})
 
       {:noreply, updated_socket} =
         ValentineWeb.WorkspaceLive.Threat.Show.handle_info(

--- a/valentine/test/valentine_web/live/workspace/threat_agent/index_test.exs
+++ b/valentine/test/valentine_web/live/workspace/threat_agent/index_test.exs
@@ -82,7 +82,8 @@ defmodule ValentineWeb.WorkspaceLive.ThreatAgent.IndexTest do
     end
 
     test "handles not found threat agent", %{socket: socket} do
-      with_mock Composer, get_threat_agent!: fn _id -> nil end do
+      with_mock Composer,
+        get_threat_agent_for_workspace: fn _workspace_id, _id -> nil end do
         {:noreply, updated_socket} =
           ValentineWeb.WorkspaceLive.ThreatAgent.Index.handle_event(
             "delete",

--- a/valentine/test/valentine_web/live/workspace/workspace_idor_test.exs
+++ b/valentine/test/valentine_web/live/workspace/workspace_idor_test.exs
@@ -1,0 +1,158 @@
+defmodule ValentineWeb.WorkspaceLive.WorkspaceIdorTest do
+  use ValentineWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Valentine.ComposerFixtures
+
+  alias Valentine.Composer
+
+  test "forged delete events cannot delete records from another workspace", %{conn: conn} do
+    workspace = workspace_fixture(%{owner: "attacker@localhost"})
+    other_workspace = workspace_fixture(%{owner: "other.owner@localhost"})
+
+    assumption = assumption_fixture(%{workspace_id: other_workspace.id})
+    mitigation = mitigation_fixture(%{workspace_id: other_workspace.id})
+    threat = threat_fixture(%{workspace_id: other_workspace.id})
+    evidence = evidence_fixture(%{workspace_id: other_workspace.id})
+    threat_agent = threat_agent_fixture(%{workspace_id: other_workspace.id})
+
+    api_key = api_key_fixture(%{workspace_id: other_workspace.id})
+
+    conn = Phoenix.ConnTest.init_test_session(conn, %{user_id: workspace.owner})
+
+    attempts = [
+      {
+        "/workspaces/#{workspace.id}/assumptions",
+        assumption.id,
+        fn -> Composer.get_assumption!(assumption.id) end
+      },
+      {
+        "/workspaces/#{workspace.id}/mitigations",
+        mitigation.id,
+        fn -> Composer.get_mitigation!(mitigation.id) end
+      },
+      {
+        "/workspaces/#{workspace.id}/threats",
+        threat.id,
+        fn -> Composer.get_threat!(threat.id) end
+      },
+      {
+        "/workspaces/#{workspace.id}/evidence",
+        evidence.id,
+        fn -> Composer.get_evidence!(evidence.id) end
+      },
+      {
+        "/workspaces/#{workspace.id}/threat_agents",
+        threat_agent.id,
+        fn -> Composer.get_threat_agent!(threat_agent.id) end
+      },
+      {
+        "/workspaces/#{workspace.id}/api_keys",
+        api_key.id,
+        fn -> Composer.get_api_key(api_key.id) end
+      }
+    ]
+
+    Enum.each(attempts, fn {path, foreign_id, reload} ->
+      {:ok, view, _html} = live(conn, path)
+
+      view
+      |> render_hook("delete", %{"id" => foreign_id})
+
+      assert reload.()
+    end)
+  end
+
+  test "forged form workspace IDs cannot move records between workspaces", %{conn: conn} do
+    workspace = workspace_fixture(%{owner: "attacker@localhost"})
+    other_workspace = workspace_fixture(%{owner: "other.owner@localhost"})
+    assumption = assumption_fixture(%{workspace_id: workspace.id})
+    mitigation = mitigation_fixture(%{workspace_id: workspace.id})
+    threat = threat_fixture(%{workspace_id: workspace.id})
+    threat_agent = threat_agent_fixture(%{workspace_id: workspace.id})
+
+    conn = Phoenix.ConnTest.init_test_session(conn, %{user_id: workspace.owner})
+
+    {:ok, assumption_view, _html} =
+      live(conn, "/workspaces/#{workspace.id}/assumptions/#{assumption.id}/edit")
+
+    assumption_view
+    |> element("#assumptions-form")
+    |> render_submit(%{
+      "assumption" => %{
+        "content" => "updated assumption",
+        "workspace_id" => other_workspace.id
+      }
+    })
+
+    {:ok, mitigation_view, _html} =
+      live(conn, "/workspaces/#{workspace.id}/mitigations/#{mitigation.id}/edit")
+
+    mitigation_view
+    |> element("#mitigations-form")
+    |> render_submit(%{
+      "mitigation" => %{
+        "content" => "updated mitigation",
+        "workspace_id" => other_workspace.id
+      }
+    })
+
+    {:ok, threat_agent_view, _html} =
+      live(conn, "/workspaces/#{workspace.id}/threat_agents/#{threat_agent.id}/edit")
+
+    threat_agent_view
+    |> element("#threat-agents-form")
+    |> render_submit(%{
+      "threat_agent" => %{
+        "name" => "Updated threat agent",
+        "workspace_id" => other_workspace.id
+      }
+    })
+
+    {:ok, threat_view, _html} =
+      live(conn, "/workspaces/#{workspace.id}/threats/#{threat.id}")
+
+    render_hook(threat_view, "update_field", %{
+      "_target" => ["workspace_id"],
+      "workspace_id" => other_workspace.id
+    })
+
+    render_hook(threat_view, "save", %{})
+
+    assert Composer.get_assumption!(assumption.id).workspace_id == workspace.id
+    assert Composer.get_mitigation!(mitigation.id).workspace_id == workspace.id
+    assert Composer.get_threat!(threat.id).workspace_id == workspace.id
+    assert Composer.get_threat_agent!(threat_agent.id).workspace_id == workspace.id
+  end
+
+  test "nested routes reject IDs belonging to another workspace", %{conn: conn} do
+    workspace = workspace_fixture(%{owner: "attacker@localhost"})
+    other_workspace = workspace_fixture(%{owner: "other.owner@localhost"})
+    assumption = assumption_fixture(%{workspace_id: other_workspace.id})
+    mitigation = mitigation_fixture(%{workspace_id: other_workspace.id})
+    threat = threat_fixture(%{workspace_id: other_workspace.id})
+    evidence = evidence_fixture(%{workspace_id: other_workspace.id})
+    threat_agent = threat_agent_fixture(%{workspace_id: other_workspace.id})
+
+    review_run =
+      threat_model_quality_review_run_fixture(%{
+        workspace_id: other_workspace.id,
+        owner: other_workspace.owner
+      })
+
+    conn = Phoenix.ConnTest.init_test_session(conn, %{user_id: workspace.owner})
+
+    paths = [
+      "/workspaces/#{workspace.id}/assumptions/#{assumption.id}/edit",
+      "/workspaces/#{workspace.id}/mitigations/#{mitigation.id}/edit",
+      "/workspaces/#{workspace.id}/threats/#{threat.id}",
+      "/workspaces/#{workspace.id}/evidence/#{evidence.id}",
+      "/workspaces/#{workspace.id}/threat_agents/#{threat_agent.id}/edit",
+      "/workspaces/#{workspace.id}/threat_model/reviews/#{review_run.id}"
+    ]
+
+    Enum.each(paths, fn path ->
+      assert_raise Ecto.NoResultsError, fn -> live(conn, path) end
+    end)
+  end
+end


### PR DESCRIPTION
This pull request strengthens workspace-level data access control across several modules by ensuring that all entity fetches (such as assumptions, evidence, threats, brainstorm items, etc.) are scoped to the current workspace. It introduces new helper functions in `Valentine.Composer` for fetching entities by `workspace_id`, updates all relevant LiveView modules to use these helpers, and adds parameter sanitization to prevent tampering with workspace IDs in forms.

**Workspace-scoped entity access:**

* Added generic helper functions (`get_workspace_entity!`, `get_workspace_entity`, and related query/preload helpers) to `Valentine.Composer` to fetch entities by `workspace_id` and `id`, ensuring all entity lookups are workspace-scoped.
* Added workspace-scoped fetch functions for `Assumption`, `Threat`, `ThreatAgent`, `Mitigation`, `Evidence`, `ApiKey`, and `BrainstormItem` in `Valentine.Composer`. [[1]](diffhunk://#diff-1d7332ae6c08cc7b7ef26019461261e7c9d36ebb690fe3624280fe7c78ae809bR482-R489) [[2]](diffhunk://#diff-1d7332ae6c08cc7b7ef26019461261e7c9d36ebb690fe3624280fe7c78ae809bR585-R592) [[3]](diffhunk://#diff-1d7332ae6c08cc7b7ef26019461261e7c9d36ebb690fe3624280fe7c78ae809bR700-R707) [[4]](diffhunk://#diff-1d7332ae6c08cc7b7ef26019461261e7c9d36ebb690fe3624280fe7c78ae809bR890-R897) [[5]](diffhunk://#diff-1d7332ae6c08cc7b7ef26019461261e7c9d36ebb690fe3624280fe7c78ae809bR2011-R2014) [[6]](diffhunk://#diff-1d7332ae6c08cc7b7ef26019461261e7c9d36ebb690fe3624280fe7c78ae809bR2546-R2552) [[7]](diffhunk://#diff-1d7332ae6c08cc7b7ef26019461261e7c9d36ebb690fe3624280fe7c78ae809bR2152-R2159) [[8]](diffhunk://#diff-1d7332ae6c08cc7b7ef26019461261e7c9d36ebb690fe3624280fe7c78ae809bR276-R283)

**LiveView module updates:**

* Updated all LiveView modules (Assumption, Evidence, Brainstorm, ApiKey) to use the new workspace-scoped fetch functions, replacing direct `get_*!(id)` calls with `get_*_for_workspace!(workspace_id, id, ...)` to enforce access control. [[1]](diffhunk://#diff-f5c551a9dbaa360c162f876b70134699300fa9897d19d413670fe2efd2cd78adL33-R49) [[2]](diffhunk://#diff-f5c551a9dbaa360c162f876b70134699300fa9897d19d413670fe2efd2cd78adL60-R83) [[3]](diffhunk://#diff-f5c551a9dbaa360c162f876b70134699300fa9897d19d413670fe2efd2cd78adL106-R122) [[4]](diffhunk://#diff-73b9eeec43ac22ac566d2ab15bc16e76e42657442da071d1d98e4dafbeb94f8dL37-R42) [[5]](diffhunk://#diff-73b9eeec43ac22ac566d2ab15bc16e76e42657442da071d1d98e4dafbeb94f8dL49-R55) [[6]](diffhunk://#diff-73b9eeec43ac22ac566d2ab15bc16e76e42657442da071d1d98e4dafbeb94f8dL61-R72) [[7]](diffhunk://#diff-73b9eeec43ac22ac566d2ab15bc16e76e42657442da071d1d98e4dafbeb94f8dL74-R85) [[8]](diffhunk://#diff-a31053d7503358b974991ff958cdeb7082f10dd063280135f57322aa41587723L43-L56) [[9]](diffhunk://#diff-9cfe6769d84da64bc335607a23b794131c97ef0f58d0bfef3594ac26b9c24f8cL38-R38) [[10]](diffhunk://#diff-804d44fa76d82d24ee92e1e6b2d9f3f99edcbc0fc8f5c51d85019d87446a75eaL108-R108) [[11]](diffhunk://#diff-804d44fa76d82d24ee92e1e6b2d9f3f99edcbc0fc8f5c51d85019d87446a75eaL137-R137) [[12]](diffhunk://#diff-804d44fa76d82d24ee92e1e6b2d9f3f99edcbc0fc8f5c51d85019d87446a75eaL159-R159) [[13]](diffhunk://#diff-804d44fa76d82d24ee92e1e6b2d9f3f99edcbc0fc8f5c51d85019d87446a75eaL224-R224) [[14]](diffhunk://#diff-804d44fa76d82d24ee92e1e6b2d9f3f99edcbc0fc8f5c51d85019d87446a75eaL245-R245) [[15]](diffhunk://#diff-804d44fa76d82d24ee92e1e6b2d9f3f99edcbc0fc8f5c51d85019d87446a75eaL299-R299) [[16]](diffhunk://#diff-804d44fa76d82d24ee92e1e6b2d9f3f99edcbc0fc8f5c51d85019d87446a75eaL322-R322) [[17]](diffhunk://#diff-8267c74fc05b028f938cb05aa88335513e06406c5600749aca1500f2306bf7beL505-R515)

**Form parameter security:**

* In the Assumption form component, removed the hidden workspace ID input and added server-side parameter sanitization to always set `workspace_id` from the trusted socket assigns, preventing form tampering. [[1]](diffhunk://#diff-e9854a5043654bdb5b80fc424f8f0f6c8f66cedb112fcaccf186d56f46af328eL47) [[2]](diffhunk://#diff-e9854a5043654bdb5b80fc424f8f0f6c8f66cedb112fcaccf186d56f46af328eL73-R82) [[3]](diffhunk://#diff-e9854a5043654bdb5b80fc424f8f0f6c8f66cedb112fcaccf186d56f46af328eR134-R147)

These changes collectively ensure that all entity access is properly scoped to the current workspace, improving security and data integrity across the application.