### PR TITLE
feat: add dedicated guardian secret

### DIFF
--- a/valentine/config/config.exs
+++ b/valentine/config/config.exs
@@ -80,10 +80,7 @@ config :valentine, Valentine.Guardian,
   ttl: {7, :days},
   token_ttl: %{
     "api_key" => {365, :days}
-  },
-  secret_key:
-    System.get_env("SECRET_KEY_BASE") ||
-      "yllTwLg1HsDDRwYa7O5gaJX4f2TcLPkQ/yKcLZ3H7oY3jBG3TrB8Bf20ei+TQuDv"
+  }
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/valentine/config/dev.exs
+++ b/valentine/config/dev.exs
@@ -26,6 +26,11 @@ config :valentine, ValentineWeb.Endpoint,
     esbuild: {Esbuild, :install_and_run, [:valentine, ~w(--sourcemap=inline --watch)]}
   ]
 
+# This checked-in key is only used for local development. Production requires a
+# separate GUARDIAN_SECRET_KEY at runtime.
+config :valentine, Valentine.Guardian,
+  secret_key: "navigator-development-only-guardian-secret-key-000000000000000000"
+
 # ## SSL Support
 #
 # In order to use HTTPS in development, a self-signed

--- a/valentine/config/runtime.exs
+++ b/valentine/config/runtime.exs
@@ -79,6 +79,24 @@ if config_env() == :prod do
       You can generate one by calling: mix phx.gen.secret
       """
 
+  guardian_secret_key =
+    case System.get_env("GUARDIAN_SECRET_KEY") do
+      secret when is_binary(secret) and byte_size(secret) >= 64 ->
+        secret
+
+      nil ->
+        raise """
+        environment variable GUARDIAN_SECRET_KEY is missing.
+        Generate a dedicated JWT signing key by calling: mix phx.gen.secret
+        """
+
+      secret ->
+        raise """
+        environment variable GUARDIAN_SECRET_KEY must contain at least 64 bytes; \
+        received #{byte_size(secret)}. Generate one by calling: mix phx.gen.secret
+        """
+    end
+
   host = System.get_env("PHX_HOST") || "example.com"
   port = String.to_integer(System.get_env("PORT") || "4000")
 
@@ -95,6 +113,8 @@ if config_env() == :prod do
       port: port
     ],
     secret_key_base: secret_key_base
+
+  config :valentine, Valentine.Guardian, secret_key: guardian_secret_key
 
   # ## SSL Support
   #

--- a/valentine/config/test.exs
+++ b/valentine/config/test.exs
@@ -19,6 +19,9 @@ config :valentine, ValentineWeb.Endpoint,
   secret_key_base: "TnTYuur9uww/9Ff4AGG6lMxhGeQikthVNKzskqJ6tT+rXc5KX43yQAdGFRGux4Ra",
   server: false
 
+config :valentine, Valentine.Guardian,
+  secret_key: "navigator-test-only-guardian-secret-key-000000000000000000000000"
+
 # In test we don't send emails
 config :valentine, Valentine.Mailer, adapter: Swoosh.Adapters.Test
 

--- a/valentine/test/valentine/runtime_config_test.exs
+++ b/valentine/test/valentine/runtime_config_test.exs
@@ -1,0 +1,56 @@
+defmodule Valentine.RuntimeConfigTest do
+  use ExUnit.Case, async: false
+
+  @runtime_config Path.expand("../../config/runtime.exs", __DIR__)
+  @managed_environment ~w(DATABASE_URL SECRET_KEY_BASE GUARDIAN_SECRET_KEY)
+
+  setup do
+    original_environment =
+      Map.new(@managed_environment, fn variable -> {variable, System.get_env(variable)} end)
+
+    System.put_env("DATABASE_URL", "ecto://postgres:postgres@localhost/valentine_test")
+    System.put_env("SECRET_KEY_BASE", String.duplicate("s", 64))
+
+    on_exit(fn ->
+      Enum.each(original_environment, fn
+        {variable, nil} -> System.delete_env(variable)
+        {variable, value} -> System.put_env(variable, value)
+      end)
+    end)
+
+    :ok
+  end
+
+  test "production refuses to start without a JWT signing key" do
+    System.delete_env("GUARDIAN_SECRET_KEY")
+
+    assert_raise RuntimeError, ~r/GUARDIAN_SECRET_KEY is missing/, fn ->
+      read_production_config()
+    end
+  end
+
+  test "production refuses a short JWT signing key" do
+    System.put_env("GUARDIAN_SECRET_KEY", "public-or-guessable")
+
+    assert_raise RuntimeError, ~r/GUARDIAN_SECRET_KEY must contain at least 64 bytes/, fn ->
+      read_production_config()
+    end
+  end
+
+  test "production configures Guardian with the runtime JWT signing key" do
+    guardian_secret_key = String.duplicate("g", 64)
+    System.put_env("GUARDIAN_SECRET_KEY", guardian_secret_key)
+
+    guardian_config =
+      @runtime_config
+      |> Config.Reader.read!(env: :prod)
+      |> Keyword.fetch!(:valentine)
+      |> Keyword.fetch!(Valentine.Guardian)
+
+    assert guardian_config[:secret_key] == guardian_secret_key
+  end
+
+  defp read_production_config do
+    Config.Reader.read!(@runtime_config, env: :prod)
+  end
+end


### PR DESCRIPTION
This pull request improves the way Guardian's JWT secret key is managed for the `Valentine.Guardian` module across different environments. The changes remove hardcoded or fallback secrets from the main config, enforce stricter runtime checks for production, and add tests to ensure correct configuration and error handling.

**Guardian secret key management:**

* Removed the hardcoded fallback `secret_key` from `config.exs` to prevent accidental use of insecure defaults in production.
* Added explicit `secret_key` values for development and test environments in `dev.exs` and `test.exs`, using clearly marked, non-production keys. [[1]](diffhunk://#diff-7ad66e86763818420168cd359603c3fe7fcc98a18886ddebb09466c441d31986R29-R33) [[2]](diffhunk://#diff-41aeb76d1f37b3c5b72121b37066689be975c5881f4080f2ddbc8c6c8e50ffb1R22-R24)

**Production runtime configuration:**

* Updated `runtime.exs` to require the `GUARDIAN_SECRET_KEY` environment variable in production, with a minimum length check (64 bytes), and clear error messages if missing or too short.
* Configured Guardian to use the runtime-provided secret key in production.

**Testing and validation:**

* Added `Valentine.RuntimeConfigTest` to verify that production refuses to start without a valid JWT signing key, and that Guardian is correctly configured at runtime.