### PR TITLE
feat: lightllm integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,13 @@ You can run the app locally using docker compose. It is not recommended to use t
 docker compose up
 ```
 
-will build the latest image and run the app on `http://localhost:4000`. If you would like to use the LLM functionality, you need to provide your own OPENAI API key for `gpt-4o-mini`.
+will build the latest image and run the app on `http://localhost:4000`. To use the LLM functionality, provide the URL and gateway key for a LiteLLM proxy that is reachable from the app container. `LITELLM_MODEL` selects a model alias configured in that gateway and defaults to `gpt-4o-mini`.
 
 ```
-OPENAI_API_KEY=sk-proj... docker compose up
+LITELLM_BASE_URL=https://llm.example.com/v1 \
+LITELLM_API_KEY=sk-litellm... \
+LITELLM_MODEL=navigator-analysis \
+docker compose up
 ```
 
 If you make changes to the source code, then you need to rebuild the image: 
@@ -94,14 +97,17 @@ Typical agent-driven workflow:
 4. Tell your AI to archive the change once the code and specs are in sync.
 
 
-## OpenAI on Azure
+## LiteLLM gateway
 
-You can also use OpenAI on Azure. You need to provide the following environment variables:
+Navigator sends all AI-assisted requests through a [LiteLLM proxy](https://docs.litellm.ai/docs/proxy/quick_start) using its OpenAI-compatible API. Configure the full API base URL (normally ending in `/v1`), a LiteLLM virtual or gateway key, and optionally a model alias:
 
 ```
-AZURE_OPENAI_ENDPOINT=
-AZURE_OPENAI_KEY=
+LITELLM_BASE_URL=https://llm.example.com/v1
+LITELLM_API_KEY=sk-litellm...
+LITELLM_MODEL=navigator-analysis # Optional; defaults to gpt-4o-mini
 ```
+
+Direct `OPENAI_API_KEY`, `OPENAI_MODEL`, and `AZURE_OPENAI_*` configuration is no longer supported. Upstream provider credentials and routing belong in LiteLLM. If the gateway URL or key is missing, Navigator rejects AI requests locally rather than falling back to a direct provider.
 
 ## Optional Auth
 
@@ -190,10 +196,13 @@ Vous pouvez exécuter l’application localement en utilisant docker compose. Il
 ```
 docker compose up
 ```
-construira la dernière image et exécutera l'application sur `http://localhost:4000`. Si vous souhaitez utiliser la fonctionnalité LLM, vous devez fournir votre propre OPENAI API clé pour `gpt-4o-mini`.
+construira la dernière image et exécutera l'application sur `http://localhost:4000`. Pour utiliser les fonctionnalités LLM, fournissez l'URL et la clé d'une passerelle LiteLLM accessible depuis le conteneur de l'application. `LITELLM_MODEL` sélectionne un alias de modèle configuré dans cette passerelle et utilise `gpt-4o-mini` par défaut.
 
 ```
-OPENAI_API_KEY=sk-proj... docker compose up
+LITELLM_BASE_URL=https://llm.example.com/v1 \
+LITELLM_API_KEY=sk-litellm... \
+LITELLM_MODEL=navigator-analysis \
+docker compose up
 ```
 
 Si vous apportez des modifications au code source, vous devez alors reconstruire l'image : 
@@ -230,13 +239,17 @@ Flux de travail typique avec l'agent :
 3. Demandez à votre IA d'implémenter le changement approuvé.
 4. Demandez à votre IA d'archiver le changement une fois que le code et les spécifications sont synchronisés.
 
-## OpenAI sur Azure 
-Vous pouvez également utiliser OpenAI sur Azure. Vous devez fournir les variables d'environnement suivantes :
+## Passerelle LiteLLM
+
+Navigator achemine toutes les requêtes assistées par IA par l'intermédiaire d'un [proxy LiteLLM](https://docs.litellm.ai/docs/proxy/quick_start) utilisant son API compatible avec OpenAI. Configurez l'URL de base complète de l'API (se terminant normalement par `/v1`), une clé virtuelle ou de passerelle LiteLLM et, facultativement, un alias de modèle :
 
 ```
-AZURE_OPENAI_ENDPOINT=
-AZURE_OPENAI_KEY=
+LITELLM_BASE_URL=https://llm.example.com/v1
+LITELLM_API_KEY=sk-litellm...
+LITELLM_MODEL=navigator-analysis # Facultatif; utilise gpt-4o-mini par défaut
 ```
+
+La configuration directe avec `OPENAI_API_KEY`, `OPENAI_MODEL` et `AZURE_OPENAI_*` n'est plus prise en charge. Les identifiants des fournisseurs en amont et les règles de routage doivent être configurés dans LiteLLM. Si l'URL ou la clé de la passerelle est absente, Navigator rejette localement les requêtes IA au lieu de revenir à un fournisseur direct.
 
 ## Authentification facultative
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,9 @@ services:
       - db
     environment:
       DATABASE_URL: "ecto://postgres:postgres@db/postgres"
-      OPENAI_API_KEY: $OPENAI_API_KEY
+      LITELLM_BASE_URL: $LITELLM_BASE_URL
+      LITELLM_API_KEY: $LITELLM_API_KEY
+      LITELLM_MODEL: ${LITELLM_MODEL:-gpt-4o-mini}
       PHX_HOST: "localhost"
       SECRET_KEY_BASE: "LZcrpJerGFAOAk9tmX++gOlapKEvjcahler184AEFKAEpnQPRzKtTN737XXsrdFG" # Generate a secret key with `mix phx.gen.secret` if you use this in production
   db:

--- a/openspec/changes/use-litellm-gateway/.openspec.yaml
+++ b/openspec/changes/use-litellm-gateway/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/use-litellm-gateway/design.md
+++ b/openspec/changes/use-litellm-gateway/design.md
@@ -1,0 +1,52 @@
+## Context
+
+`Valentine.AIProvider` is the shared configuration boundary for chat, control categorization, threat generation, repository analysis, and threat-model quality review. It currently selects either an OpenAI model spec or an Azure model spec and translates multiple provider-specific environment variables into ReqLLM request options. LiteLLM exposes an OpenAI-compatible API and centralizes upstream credentials and routing, so Navigator no longer needs direct-provider selection.
+
+The change affects runtime configuration, a shared provider module, one diagnostic log line, tests, Docker Compose, and setup documentation. It does not affect schemas, routes, exports, permissions, or real-time collaboration.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Send all Navigator AI traffic to the configured LiteLLM OpenAI-compatible base URL.
+- Authenticate only with the configured LiteLLM gateway key.
+- Allow any LiteLLM model alias, including aliases absent from ReqLLM's bundled model catalog.
+- Fail locally before an AI request when gateway URL or key configuration is missing, preventing accidental fallback to the public OpenAI endpoint.
+- Preserve existing maximum-token and per-call option behavior.
+
+**Non-Goals:**
+
+- Provisioning LiteLLM, managing its virtual keys, or defining its upstream providers and routing rules.
+- Supporting direct OpenAI or Azure OpenAI credentials alongside the gateway.
+- Changing workspace API keys, application authentication, authorization, database schemas, routes, exports, or LiveView collaboration semantics.
+
+## Decisions
+
+1. **Use ReqLLM's OpenAI provider with per-request `base_url` and `api_key`.** LiteLLM's proxy implements the OpenAI protocol, and ReqLLM documents custom `base_url` as the supported path for OpenAI-compatible services. This avoids a new provider module or dependency. A custom LiteLLM-specific ReqLLM provider was considered but would duplicate protocol behavior without adding product value.
+
+2. **Store gateway settings under `config :req_llm, :litellm`.** `valentine/config/runtime.exs` will load `LITELLM_BASE_URL` and `LITELLM_API_KEY` into one keyword list and load the alias from `LITELLM_MODEL`. Keeping the gateway contract grouped prevents old direct-provider settings from participating in selection.
+
+3. **Represent the model as `%{provider: :openai, id: alias}`.** ReqLLM accepts a model map to bypass catalog lookup. This is necessary because LiteLLM aliases are deployment-defined and may not exist in ReqLLM's static model catalog. The affected quality-review diagnostic will inspect rather than interpolate the model value.
+
+4. **Validate gateway URL and key lazily in `Valentine.AIProvider.request_opts/2`.** AI functionality is optional, so application startup remains available without gateway configuration. When an AI workflow is invoked, missing configuration raises a targeted error before ReqLLM can fall back to its public OpenAI defaults or ambient `OPENAI_API_KEY` values.
+
+5. **Replace rather than deprecate the old runtime contract.** Supporting both configurations would preserve ambiguity about whether requests bypass the gateway. Rollback is performed by deploying the previous Navigator release, not by toggling provider selection in this version.
+
+## Risks / Trade-offs
+
+- [Gateway outage becomes a single point of failure for AI features] → Navigator's non-AI workflows remain available, while AI request failures continue through existing workflow error handling.
+- [A configured alias may not support structured output or tools] → Operators must map `LITELLM_MODEL` to a compatible route; Navigator continues sending the same structured-output requests it sends today.
+- [Base URLs without the OpenAI-compatible path fail] → Documentation requires the full proxy API base URL, normally ending in `/v1`, and tests verify the value is passed through unchanged apart from removing trailing slashes.
+- [Removing direct-provider variables is a breaking deployment change] → Document the exact replacement variables and require gateway configuration before rollout.
+
+## Migration Plan
+
+1. Create or select a LiteLLM virtual key and a model alias that supports Navigator's chat, tool, and structured-output usage.
+2. Set `LITELLM_BASE_URL` to the gateway's OpenAI-compatible API root, `LITELLM_API_KEY` to the gateway key, and optionally `LITELLM_MODEL` to the chosen alias.
+3. Remove the old OpenAI/Azure variables and deploy this version.
+4. Exercise an interactive AI action and a background analysis/review workflow through the gateway.
+5. Roll back by restoring the previous Navigator version and its previous provider variables if the gateway route is not ready.
+
+## Open Questions
+
+None. Gateway provisioning and alias policy remain owned by the deployment's LiteLLM configuration.

--- a/openspec/changes/use-litellm-gateway/proposal.md
+++ b/openspec/changes/use-litellm-gateway/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Navigator currently authenticates directly to OpenAI or Azure OpenAI with provider-specific credentials. The deployment is moving to LiteLLM as the single LLM gateway, so Navigator needs to send all AI-assisted requests through that OpenAI-compatible gateway using gateway credentials and model aliases.
+
+## What Changes
+
+- Route every AI-assisted request through one configured LiteLLM base URL using the OpenAI-compatible protocol.
+- Authenticate requests with a LiteLLM gateway key and select the gateway model alias from LiteLLM-specific runtime configuration.
+- Keep the existing AI-assisted user workflows and request tuning, including the maximum token limit, unchanged.
+- Update Docker Compose and operator documentation to describe the LiteLLM gateway configuration.
+- **BREAKING**: Remove the direct `OPENAI_API_KEY`, `OPENAI_MODEL`, and `AZURE_OPENAI_*` runtime configuration contract. Deployments must provide `LITELLM_BASE_URL`, `LITELLM_API_KEY`, and optionally `LITELLM_MODEL`.
+- Non-goals: deploying or configuring the LiteLLM service itself, changing model routing policy inside LiteLLM, or changing Navigator's workspace API-key feature.
+- Rollout: configure and validate the LiteLLM gateway variables before deploying this version; no database migration is required.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `ai-assisted-analysis`: AI-assisted analysis uses the configured LiteLLM gateway rather than direct OpenAI or Azure OpenAI provider credentials.
+
+## Impact
+
+- Runtime configuration in `valentine/config/runtime.exs`.
+- Provider request construction in `Valentine.AIProvider`, which is shared by interactive AI features, repository analysis, and threat-model quality review.
+- Runtime configuration tests, Docker Compose environment forwarding, and English/French setup documentation.
+- The existing ReqLLM dependency remains in place and uses its OpenAI-compatible `base_url` and `api_key` request options; no new dependency is required.

--- a/openspec/changes/use-litellm-gateway/specs/ai-assisted-analysis/spec.md
+++ b/openspec/changes/use-litellm-gateway/specs/ai-assisted-analysis/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: Provider-agnostic AI integration
+Navigator SHALL route all AI-assisted analysis through the configured LiteLLM gateway using its OpenAI-compatible API rather than authenticating directly to upstream model providers.
+
+#### Scenario: Running AI-assisted analysis through LiteLLM
+- **WHEN** a workspace uses AI-assisted analysis and the LiteLLM gateway URL, gateway key, and model alias are configured
+- **THEN** Navigator routes repository-analysis and threat-model quality-review requests to that gateway
+- **AND** authenticates with the gateway key
+- **AND** sends the configured model alias while leaving upstream-provider selection to LiteLLM
+- **AND** the user-facing workflow remains unchanged regardless of the upstream provider selected by LiteLLM
+
+#### Scenario: Rejecting incomplete gateway configuration
+- **WHEN** an AI-assisted workflow is invoked without a configured LiteLLM gateway URL or gateway key
+- **THEN** Navigator fails the request with a gateway-configuration error before contacting an LLM endpoint
+- **AND** does not fall back to direct OpenAI or Azure OpenAI credentials

--- a/openspec/changes/use-litellm-gateway/tasks.md
+++ b/openspec/changes/use-litellm-gateway/tasks.md
@@ -1,0 +1,23 @@
+## 1. Gateway Configuration
+
+- [x] 1.1 Replace direct OpenAI and Azure runtime settings with grouped LiteLLM gateway URL, key, and model-alias settings.
+- [x] 1.2 Update `Valentine.AIProvider` to construct custom OpenAI-compatible model inputs and validated LiteLLM request options without direct-provider fallback.
+- [x] 1.3 Update affected diagnostic logging for the custom model representation.
+
+## 2. Automated Coverage
+
+- [x] 2.1 Add focused `Valentine.AIProvider` tests for model aliases, gateway request options, option precedence, token limits, and incomplete configuration.
+- [x] 2.2 Extend runtime configuration tests to verify LiteLLM environment-variable mapping and removal of legacy direct-provider settings.
+
+## 3. Deployment Guidance
+
+- [x] 3.1 Replace Docker Compose's OpenAI key forwarding with LiteLLM gateway variables.
+- [x] 3.2 Update the English and French README setup instructions with the LiteLLM migration contract.
+
+## 4. Verification
+
+- [x] 4.1 Run `make fmt` and confirm formatting produces no unexpected changes.
+- [x] 4.2 Run focused AI-provider and runtime-config tests, then run `make test`.
+- [x] 4.3 Confirm the accepted gateway behavior is represented in the OpenSpec delta and record the manual gateway workflow check as deployment-dependent.
+
+Manual gateway workflow check: deployment-dependent and not run locally because no LiteLLM gateway endpoint or key was provided.

--- a/valentine/config/runtime.exs
+++ b/valentine/config/runtime.exs
@@ -20,20 +20,20 @@ if System.get_env("PHX_SERVER") do
   config :valentine, ValentineWeb.Endpoint, server: true
 end
 
-# Configure req_llm
-config :req_llm, openai_api_key: System.get_env("OPENAI_API_KEY")
-config :req_llm, azure_openai_api_key: System.get_env("AZURE_OPENAI_KEY")
-config :req_llm, azure_openai_endpoint: System.get_env("AZURE_OPENAI_ENDPOINT")
+# Configure ReqLLM to use the OpenAI-compatible LiteLLM gateway.
+litellm_test_defaults =
+  if config_env() == :test do
+    [base_url: "http://litellm.test/v1", api_key: "test-litellm-key"]
+  else
+    []
+  end
 
 config :req_llm,
-  azure: [
-    api_key: System.get_env("AZURE_OPENAI_KEY"),
-    base_url: System.get_env("AZURE_OPENAI_BASE_URL"),
-    deployment: System.get_env("AZURE_OPENAI_DEPLOYMENT"),
-    api_version: System.get_env("AZURE_OPENAI_API_VERSION")
-  ]
-
-config :req_llm, model: System.get_env("OPENAI_MODEL", "gpt-4o-mini")
+  litellm: [
+    base_url: System.get_env("LITELLM_BASE_URL") || litellm_test_defaults[:base_url],
+    api_key: System.get_env("LITELLM_API_KEY") || litellm_test_defaults[:api_key]
+  ],
+  model: System.get_env("LITELLM_MODEL", "gpt-4o-mini")
 
 config :ueberauth, Ueberauth.Strategy.Cognito,
   auth_domain: System.get_env("COGNITO_DOMAIN"),

--- a/valentine/lib/valentine/ai_provider.ex
+++ b/valentine/lib/valentine/ai_provider.ex
@@ -1,124 +1,36 @@
 defmodule Valentine.AIProvider do
   @moduledoc false
 
-  require Logger
-
   @default_model "gpt-4o-mini"
   @default_max_tokens 4096
 
-  def model_spec(component_name) do
-    model = model()
+  def model_spec(_component_name), do: %{provider: :openai, id: model()}
 
-    case provider() do
-      {:openai, _opts} ->
-        "openai:#{model}"
+  def request_opts(component_name, extra_opts \\ []) do
+    litellm_config = Keyword.new(Application.get_env(:req_llm, :litellm, []))
 
-      {:azure, _opts} ->
-        "azure:#{model}"
-
-      :none ->
-        spec = "openai:#{model}"
-        Logger.warning("[#{component_name}] No AI provider configured, falling back to #{spec}")
-        spec
-    end
-  end
-
-  def request_opts(_component_name, extra_opts \\ []) do
-    max_tokens = max_tokens()
-
-    opts =
-      case provider() do
-        {:openai, _opts} ->
-          [max_tokens: max_tokens]
-
-        {:azure, azure_opts} ->
-          azure_opts
-          |> Keyword.take([:api_key, :base_url, :deployment, :api_version])
-          |> Kernel.++(max_tokens: max_tokens)
-
-        :none ->
-          [max_tokens: max_tokens]
-      end
-      |> Keyword.merge(extra_opts)
-
-    opts
-  end
-
-  defp provider do
-    openai_key = Application.get_env(:req_llm, :openai_api_key)
-    azure_opts = azure_opts()
-
-    cond do
-      present?(openai_key) ->
-        {:openai, [api_key: openai_key]}
-
-      present?(azure_opts[:base_url]) ->
-        {:azure, azure_opts}
-
-      true ->
-        :none
-    end
-  end
-
-  defp azure_opts do
-    azure_config = Keyword.new(Application.get_env(:req_llm, :azure, []))
-
-    normalized_endpoint =
-      normalize_azure_endpoint(Application.get_env(:req_llm, :azure_openai_endpoint))
-
-    [
-      api_key: azure_config[:api_key] || Application.get_env(:req_llm, :azure_openai_api_key),
-      base_url: azure_config[:base_url] || normalized_endpoint.base_url,
-      deployment: azure_config[:deployment] || normalized_endpoint.deployment,
-      api_version: azure_config[:api_version] || normalized_endpoint.api_version
+    gateway_opts = [
+      base_url:
+        litellm_config
+        |> Keyword.get(:base_url)
+        |> normalize_base_url()
+        |> fetch_present!(:base_url, "LITELLM_BASE_URL", component_name),
+      api_key:
+        litellm_config
+        |> Keyword.get(:api_key)
+        |> fetch_present!(:api_key, "LITELLM_API_KEY", component_name)
     ]
-    |> Enum.reject(fn {_key, value} -> is_nil(value) or value == "" end)
+
+    [max_tokens: max_tokens()]
+    |> Keyword.merge(extra_opts)
+    |> Keyword.merge(gateway_opts)
   end
-
-  defp normalize_azure_endpoint(nil), do: %{base_url: nil, deployment: nil, api_version: nil}
-  defp normalize_azure_endpoint(""), do: %{base_url: nil, deployment: nil, api_version: nil}
-
-  defp normalize_azure_endpoint(endpoint) do
-    uri = URI.parse(endpoint)
-    path = uri.path || ""
-    query = URI.decode_query(uri.query || "")
-
-    deployment =
-      case Regex.run(~r{/deployments/([^/?]+)}, path, capture: :all_but_first) do
-        [value] -> value
-        _ -> nil
-      end
-
-    base_path =
-      cond do
-        String.contains?(path, "/openai/deployments/") -> "/openai"
-        String.starts_with?(path, "/openai") -> "/openai"
-        foundry_host?(uri.host) -> ""
-        true -> "/openai"
-      end
-
-    %{
-      base_url: build_base_url(uri, base_path),
-      deployment: deployment,
-      api_version: query["api-version"]
-    }
-  end
-
-  defp build_base_url(%URI{scheme: scheme, host: host, port: port}, base_path)
-       when is_binary(scheme) and is_binary(host) do
-    port_suffix = if port, do: ":#{port}", else: ""
-    "#{scheme}://#{host}#{port_suffix}#{base_path}"
-  end
-
-  defp build_base_url(_, _), do: nil
-
-  defp foundry_host?(host) when is_binary(host),
-    do: String.contains?(host, ".services.ai.azure.com")
-
-  defp foundry_host?(_), do: false
 
   defp model do
-    Application.get_env(:req_llm, :model, @default_model)
+    case Application.get_env(:req_llm, :model, @default_model) do
+      model when is_binary(model) and model != "" -> model
+      _ -> @default_model
+    end
   end
 
   defp max_tokens do
@@ -134,6 +46,18 @@ defmodule Valentine.AIProvider do
     end
   end
 
-  defp present?(value) when is_binary(value), do: value != ""
-  defp present?(value), do: not is_nil(value)
+  defp normalize_base_url(value) when is_binary(value),
+    do: value |> String.trim() |> String.trim_trailing("/")
+
+  defp normalize_base_url(value), do: value
+
+  defp fetch_present!(value, _setting, _environment_variable, _component_name)
+       when is_binary(value) and value != "",
+       do: value
+
+  defp fetch_present!(_value, setting, environment_variable, component_name) do
+    raise ArgumentError,
+          "[#{component_name}] LiteLLM gateway configuration is incomplete: " <>
+            "set #{setting} with #{environment_variable}"
+  end
 end

--- a/valentine/lib/valentine/threat_model_quality_review/runner.ex
+++ b/valentine/lib/valentine/threat_model_quality_review/runner.ex
@@ -84,7 +84,7 @@ defmodule Valentine.ThreatModelQualityReview.Runner do
     put_debug_context(:request_opts, redact_request_opts(request_opts))
 
     Logger.debug(
-      "[ThreatModelQualityReview] starting segmented review run_id=#{run_id} model_spec=#{model_spec} request_opts=#{inspect(redact_request_opts(request_opts))}"
+      "[ThreatModelQualityReview] starting segmented review run_id=#{run_id} model_spec=#{inspect(model_spec)} request_opts=#{inspect(redact_request_opts(request_opts))}"
     )
 
     review =

--- a/valentine/test/valentine/ai_provider_test.exs
+++ b/valentine/test/valentine/ai_provider_test.exs
@@ -1,0 +1,103 @@
+defmodule Valentine.AIProviderTest do
+  use ExUnit.Case, async: false
+
+  alias Valentine.AIProvider
+
+  @application_settings [:litellm, :model, :openai_api_key, :azure]
+
+  setup do
+    original_settings =
+      Map.new(@application_settings, fn setting ->
+        {setting, Application.fetch_env(:req_llm, setting)}
+      end)
+
+    original_max_tokens = System.get_env("REQ_LLM_MAX_TOKENS")
+
+    on_exit(fn ->
+      Enum.each(original_settings, fn
+        {setting, {:ok, value}} -> Application.put_env(:req_llm, setting, value)
+        {setting, :error} -> Application.delete_env(:req_llm, setting)
+      end)
+
+      case original_max_tokens do
+        nil -> System.delete_env("REQ_LLM_MAX_TOKENS")
+        value -> System.put_env("REQ_LLM_MAX_TOKENS", value)
+      end
+    end)
+
+    Application.put_env(:req_llm, :litellm,
+      base_url: "https://llm.example.test/v1/",
+      api_key: "sk-litellm"
+    )
+
+    System.delete_env("REQ_LLM_MAX_TOKENS")
+
+    :ok
+  end
+
+  test "uses a custom OpenAI model input for a LiteLLM alias" do
+    Application.put_env(:req_llm, :model, "navigator-analysis")
+
+    assert AIProvider.model_spec("Test") == %{
+             provider: :openai,
+             id: "navigator-analysis"
+           }
+  end
+
+  test "uses the default model when the configured alias is blank" do
+    Application.put_env(:req_llm, :model, "")
+
+    assert AIProvider.model_spec("Test") == %{provider: :openai, id: "gpt-4o-mini"}
+  end
+
+  test "builds request options for the LiteLLM gateway" do
+    assert AIProvider.request_opts("Test") == [
+             max_tokens: 4096,
+             base_url: "https://llm.example.test/v1",
+             api_key: "sk-litellm"
+           ]
+  end
+
+  test "preserves generation overrides without allowing gateway overrides" do
+    opts =
+      AIProvider.request_opts("Test",
+        temperature: 0.2,
+        max_tokens: 2048,
+        base_url: "https://api.openai.com/v1",
+        api_key: "direct-provider-key"
+      )
+
+    assert opts[:temperature] == 0.2
+    assert opts[:max_tokens] == 2048
+    assert opts[:base_url] == "https://llm.example.test/v1"
+    assert opts[:api_key] == "sk-litellm"
+  end
+
+  test "uses a valid maximum-token environment override" do
+    System.put_env("REQ_LLM_MAX_TOKENS", "8192")
+
+    assert AIProvider.request_opts("Test")[:max_tokens] == 8192
+  end
+
+  test "rejects a missing gateway URL even when a direct provider key is configured" do
+    Application.put_env(:req_llm, :litellm, api_key: "sk-litellm")
+    Application.put_env(:req_llm, :openai_api_key, "sk-openai")
+
+    assert_raise ArgumentError, ~r/LITELLM_BASE_URL/, fn ->
+      AIProvider.request_opts("Test")
+    end
+  end
+
+  test "rejects a missing gateway key even when Azure is configured" do
+    Application.put_env(:req_llm, :litellm, base_url: "https://llm.example.test/v1")
+
+    Application.put_env(:req_llm, :azure,
+      base_url: "https://example.openai.azure.com/openai",
+      api_key: "azure-key"
+    )
+
+    assert_raise ArgumentError, ~r/LITELLM_API_KEY/, fn ->
+      AIProvider.request_opts("Test")
+    end
+  end
+end

--- a/valentine/test/valentine/runtime_config_test.exs
+++ b/valentine/test/valentine/runtime_config_test.exs
@@ -2,7 +2,21 @@ defmodule Valentine.RuntimeConfigTest do
   use ExUnit.Case, async: false
 
   @runtime_config Path.expand("../../config/runtime.exs", __DIR__)
-  @managed_environment ~w(DATABASE_URL SECRET_KEY_BASE GUARDIAN_SECRET_KEY)
+  @managed_environment ~w(
+    DATABASE_URL
+    SECRET_KEY_BASE
+    GUARDIAN_SECRET_KEY
+    LITELLM_BASE_URL
+    LITELLM_API_KEY
+    LITELLM_MODEL
+    OPENAI_API_KEY
+    OPENAI_MODEL
+    AZURE_OPENAI_KEY
+    AZURE_OPENAI_ENDPOINT
+    AZURE_OPENAI_BASE_URL
+    AZURE_OPENAI_DEPLOYMENT
+    AZURE_OPENAI_API_VERSION
+  )
 
   setup do
     original_environment =
@@ -48,6 +62,32 @@ defmodule Valentine.RuntimeConfigTest do
       |> Keyword.fetch!(Valentine.Guardian)
 
     assert guardian_config[:secret_key] == guardian_secret_key
+  end
+
+  test "configures ReqLLM exclusively for the LiteLLM gateway" do
+    System.put_env("LITELLM_BASE_URL", "https://llm.example.test/v1")
+    System.put_env("LITELLM_API_KEY", "sk-litellm")
+    System.put_env("LITELLM_MODEL", "navigator-analysis")
+    System.put_env("OPENAI_API_KEY", "sk-openai")
+    System.put_env("OPENAI_MODEL", "gpt-4o")
+    System.put_env("AZURE_OPENAI_KEY", "azure-key")
+    System.put_env("AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com")
+
+    req_llm_config =
+      @runtime_config
+      |> Config.Reader.read!(env: :test)
+      |> Keyword.fetch!(:req_llm)
+
+    assert req_llm_config[:litellm] == [
+             base_url: "https://llm.example.test/v1",
+             api_key: "sk-litellm"
+           ]
+
+    assert req_llm_config[:model] == "navigator-analysis"
+    refute Keyword.has_key?(req_llm_config, :openai_api_key)
+    refute Keyword.has_key?(req_llm_config, :azure_openai_api_key)
+    refute Keyword.has_key?(req_llm_config, :azure_openai_endpoint)
+    refute Keyword.has_key?(req_llm_config, :azure)
   end
 
   defp read_production_config do


### PR DESCRIPTION
This pull request migrates Navigator's AI integration to require a LiteLLM gateway, removing direct OpenAI and Azure provider support. All AI-assisted requests are now routed through the configured LiteLLM OpenAI-compatible API using gateway credentials and model aliases. This impacts runtime configuration, provider selection, Docker Compose, and setup documentation in both English and French. The change is breaking: deployments must provide `LITELLM_BASE_URL`, `LITELLM_API_KEY`, and optionally `LITELLM_MODEL`—the previous `OPENAI_*` and `AZURE_OPENAI_*` variables are no longer supported.

**AI Provider Integration Changes**
- Replaced direct OpenAI/Azure provider selection in `Valentine.AIProvider` with a single LiteLLM gateway contract, removing all legacy credential handling and validation logic. Requests now require explicit LiteLLM configuration and fail early if incomplete. (`valentine/lib/valentine/ai_provider.ex`) (Fc738f87R1, [valentine/lib/valentine/ai_provider.exL137-R62](diffhunk://#diff-a7da98a44134ba71c13bb0e4ed919c8edaf9586ee05fcbbd655612736a1b77bdL137-R62))
- Updated model specification to use `%{provider: :openai, id: model_alias}` to support arbitrary LiteLLM model aliases. (`valentine/lib/valentine/ai_provider.ex`) (Fc738f87R1)
- Updated diagnostic logging to inspect the new model spec structure. (`valentine/lib/valentine/threat_model_quality_review/runner.ex`)

**Runtime and Deployment Configuration**
- Changed runtime configuration in `runtime.exs` to load only LiteLLM gateway variables, removing all OpenAI/Azure settings. Test defaults are provided for test environments. (`valentine/config/runtime.exs`)
- Updated `docker-compose.yml` to forward only LiteLLM gateway variables to the app container, removing OpenAI key forwarding. (`docker-compose.yml`)

**Documentation and Operator Guidance**
- Rewrote both English and French README setup and migration instructions to describe the new LiteLLM gateway contract and explicitly note the removal of direct-provider variables. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L56-R62) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97-R111) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L193-R205) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L233-R253)
- Added OpenSpec design, proposal, requirements, and migration documentation for the gateway integration. (`openspec/changes/use-litellm-gateway/`) [[1]](diffhunk://#diff-0070f7540363b039802452fcf0ff34eb8071c74fedb796b4964c75d73ed5bcc2R1-R52) [[2]](diffhunk://#diff-88bd64600caa99407469d6cca820b4cf411b6be6c5403e7b88c743f1d1e7fffaR1-R30) [[3]](diffhunk://#diff-b7ba399a9d4548f49a2a96de0be9c60a0ce104958c3eab30b22aaab0d4bc758bR1-R16) [[4]](diffhunk://#diff-0d274546ab81e6e3972df0994ae98d4d56de8f308b288fd83d9aeab825861e1aR1-R23) [[5]](diffhunk://#diff-9c9cf7db98384f980c30c2f9bd5f15d1cdfb59429ec16826621c19ab6ed36db8R1-R2)

This is a breaking change for deployments: LiteLLM gateway configuration is now required for all AI-assisted features.